### PR TITLE
feat: v0.64.0 Release Truth and Safety Freeze

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -32,7 +32,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -138,7 +138,7 @@ jobs:
           PYEOF
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: benchmark-results
           path: benchmark_results.json

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -14,13 +14,13 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -37,7 +37,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553  # v9
         with:
           script: |
             const title = `Security: cargo audit found vulnerabilities (${new Date().toISOString().split('T')[0]})`;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -41,7 +41,7 @@ jobs:
         run: rm -rf target/test-pgdata
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -104,6 +104,10 @@ jobs:
       - name: SECURITY DEFINER lint
         run: bash scripts/check_no_security_definer.sh
 
+      # v0.64.0 TRUTH-03: Reject mutable GitHub Actions refs (requires pinned SHAs).
+      - name: GitHub Actions pinning lint
+        run: bash scripts/check_github_actions_pinned.sh
+
       - name: Run pg_test suite
         env:
           RUST_TEST_THREADS: "1"
@@ -115,13 +119,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -131,7 +135,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -165,7 +169,7 @@ jobs:
 
       - name: Upload regression results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: pg_regress_results
           path: |
@@ -180,13 +184,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -196,7 +200,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -242,13 +246,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -258,19 +262,19 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
 
       - name: Cache pgrx PostgreSQL build
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.pgrx
           key: ${{ runner.os }}-pgrx-pg18-${{ env.PGRX_VERSION }}
 
       - name: Cache W3C test data
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: w3c-cache
         with:
           path: tests/w3c/data
@@ -330,13 +334,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -346,19 +350,19 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
 
       - name: Cache pgrx PostgreSQL build
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.pgrx
           key: ${{ runner.os }}-pgrx-pg18-${{ env.PGRX_VERSION }}
 
       - name: Cache W3C test data
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: w3c-cache
         with:
           path: tests/w3c/data
@@ -409,7 +413,7 @@ jobs:
 
       - name: Upload W3C test report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: w3c_report
           path: tests/w3c/report.json
@@ -427,13 +431,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -443,19 +447,19 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
 
       - name: Cache pgrx PostgreSQL build
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.pgrx
           key: ${{ runner.os }}-pgrx-pg18-${{ env.PGRX_VERSION }}
 
       - name: Cache Jena test data
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: jena-cache
         with:
           path: tests/jena/data
@@ -506,7 +510,7 @@ jobs:
 
       - name: Upload Jena conformance report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: jena_report
           path: tests/conformance/report.json
@@ -524,13 +528,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -540,7 +544,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -586,7 +590,7 @@ jobs:
 
       - name: Upload WatDiv benchmark report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: watdiv_report
           path: tests/conformance/report.json
@@ -603,13 +607,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -619,7 +623,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -674,13 +678,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -690,7 +694,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -732,13 +736,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -748,19 +752,19 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
 
       - name: Cache pgrx PostgreSQL build
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.pgrx
           key: ${{ runner.os }}-pgrx-pg18-${{ env.PGRX_VERSION }}
 
       - name: Cache OWL 2 RL test data
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: owl2rl-cache
         with:
           path: tests/owl2rl/data
@@ -821,13 +825,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -885,13 +889,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -901,7 +905,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -955,13 +959,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -971,7 +975,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -1011,13 +1015,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -1027,19 +1031,19 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
 
       - name: Cache pgrx PostgreSQL build
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.pgrx
           key: ${{ runner.os }}-pgrx-pg18-${{ env.PGRX_VERSION }}
 
       - name: Cache BSBM data
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: bsbm-cache
         with:
           path: benchmarks/bsbm/data
@@ -1103,7 +1107,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Check for unsafe dynamic SQL patterns
         run: bash scripts/check_no_string_format_in_sql.sh
 
@@ -1112,7 +1116,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Check all PT error codes are documented
         run: bash scripts/check_pt_codes.sh
 
@@ -1121,7 +1125,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Check migration script headers
         run: bash scripts/check_migration_headers.sh
 
@@ -1130,8 +1134,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Check for duplicate direct dependencies (advisory)
         run: |
           cargo tree --duplicates 2>&1 | tee /tmp/duplicates.txt || true
@@ -1147,8 +1151,8 @@ jobs:
     name: Lint - SPDX licence compliance (v0.51.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - name: Install cargo-license
         run: cargo install cargo-license --locked
       - name: Check all dependencies use allowed licences

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -35,13 +35,13 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-docs-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
 
       - name: Cache pgrx PostgreSQL build
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.pgrx/
           key: ${{ runner.os }}-pgrx-pgdata-${{ env.PGRX_VERSION }}-pg18
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install mdBook
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,10 +26,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install mdBook
         run: |
@@ -51,10 +51,10 @@ jobs:
         run: mdbook build docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: docs/book
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -37,7 +37,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -85,13 +85,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             ~/.cargo/registry
@@ -101,7 +101,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Cache cargo-pgrx binary
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: ${{ runner.os }}-cargo-pgrx-${{ env.PGRX_VERSION }}
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Extract version from tag
         id: version
@@ -212,6 +212,20 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           gh release upload "${TAG}" sbom.json --clobber
 
+      # v0.64.0 TRUTH-09: Generate release evidence dashboard artifact.
+      - name: Generate release evidence dashboard
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          bash scripts/generate_release_evidence.sh "$VERSION" || true
+
+      - name: Upload release evidence artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        if: always()
+        with:
+          name: release-evidence-${{ steps.version.outputs.version }}
+          path: target/release-evidence/
+          if-no-files-found: warn
+
   # ── 4. Build and publish Docker image ────────────────────────────────────────
   docker:
     name: Docker image (ghcr.io)
@@ -223,26 +237,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
 
       - name: Build and push
         id: docker_push
-        continue-on-error: true
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
         with:
           context: .
           push: true
@@ -258,11 +271,25 @@ jobs:
           provenance: true
           sbom: true
 
-      # v0.60.0 N7-4: Docker CVE scan — fail release if HIGH/CRITICAL CVEs found.
+      # v0.64.0 TRUTH-04: Capture the immutable image digest and verify it
+      # matches the scanned digest so the release cannot continue on build failure.
+      - name: Capture image digest
+        id: digest
+        run: |
+          DIGEST="${{ steps.docker_push.outputs.digest }}"
+          if [[ -z "$DIGEST" ]]; then
+            echo "ERROR: docker build/push did not produce a digest — build may have failed" >&2
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "Image digest: $DIGEST"
+
+      # v0.60.0 N7-4 / v0.64.0 TRUTH-04: Docker CVE scan — fail release if
+      # HIGH/CRITICAL CVEs found. Scan the immutable digest, not the mutable tag.
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8  # v0.36.0
         with:
-          image-ref: ghcr.io/grove/pg-ripple:${{ steps.version.outputs.version }}
+          image-ref: ghcr.io/grove/pg-ripple@${{ steps.digest.outputs.digest }}
           format: table
           exit-code: '1'
           severity: HIGH,CRITICAL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ Versions correspond to the milestones in [ROADMAP.md](ROADMAP.md).
 
 ---
 
+## [0.64.0] — 2026-04-27 — Release Truth and Safety Freeze
+
+**Implements the v0.64.0 roadmap: feature-status SQL API, deep /ready readiness, GitHub Actions SHA pinning, Docker release digest integrity, documentation truth pass, roadmap evidence scripts, API drift checks, `just assess-release`, release evidence dashboard, and optional-feature degradation semantics guide.**
+
+### What's new
+
+- **`pg_ripple.feature_status()`** (TRUTH-01): New SQL function returning one row per major capability with an honest status value. Status taxonomy: `implemented`, `experimental`, `planner_hint`, `manual_refresh`, `stub`, `degraded`, `planned`. Reports honest statuses for Arrow Flight (`stub`), WCOJ (`planner_hint`), SHACL-SPARQL rules (`planned`), CONSTRUCT writeback (`manual_refresh`), Citus SERVICE pruning (`planned`), and all other major features.
+
+- **Deep `/ready` readiness** (TRUTH-02): Extended `pg_ripple_http /ready` to include PostgreSQL version, extension version, and a feature-status snapshot. The response body now includes `partial_features` (all non-`implemented` features) and `degraded_features` (features with `stub` or `degraded` status).
+
+- **GitHub Actions SHA pinning** (TRUTH-03): All third-party `uses:` references in `.github/workflows/` are now pinned to full 40-character commit SHAs with the human-readable tag as a comment. New CI step `scripts/check_github_actions_pinned.sh` rejects mutable refs (`@v6`, `@stable`, branch names) — zero mutable refs permitted.
+
+- **Docker release digest integrity** (TRUTH-04): Removed `continue-on-error: true` from Docker build/push. Release job now captures the immutable image digest from the build step, fails if no digest is produced, and scans `ghcr.io/grove/pg-ripple@sha256:...` (the immutable digest) instead of a mutable tag.
+
+- **Documentation truth pass** (TRUTH-05): Corrected `plans/implementation_plan.md` pgrx 0.17 → 0.18 throughout. Updated README "What works today" to reflect v0.63.0. Added "Known limitations in v0.63.0" section to README covering Arrow Flight, WCOJ, SHACL rules, CONSTRUCT writeback, Citus pruning, and optional dependencies.
+
+- **Roadmap evidence check script** (TRUTH-06): `scripts/check_roadmap_evidence.sh` — advisory lint that flags completion-claim bullet points in CHANGELOG without evidence markers (CI test name, docs path, SQL function reference). Advisory-only in v0.64.0; will be enforced in v0.67.0.
+
+- **API drift check script** (TRUTH-07): `scripts/check_api_drift.sh` — extracts exported function names from `#[pg_extern]` annotations in `src/` and checks that each appears in at least one documentation file. Advisory-only; catches the v0.63 Citus signature drift pattern.
+
+- **`just assess-release`** (TRUTH-08): One-command release quality gate that runs migration headers lint, GitHub Actions pinning lint, SECURITY DEFINER lint, roadmap evidence check, API drift check, and version sync check. Optionally generates a release evidence report with `just assess-release VERSION`.
+
+- **Release evidence dashboard** (TRUTH-09): `scripts/generate_release_evidence.sh` generates `target/release-evidence/<version>/summary.json` and `summary.md`. Release workflow uploads the artifact to GitHub Actions and attaches it to the GitHub release.
+
+- **Degradation semantics guide** (TRUTH-10): New documentation page `docs/src/reference/degradation.md` documents expected degraded behavior, return values, warning codes, readiness behavior, and planned implementation milestones for every optional feature.
+
+- **pg_regress test** `feature_status.sql`: Asserts that `feature_status()` returns rows, all statuses are from the approved taxonomy, and specific partial features report honest status values.
+
+---
+
 ## [0.63.0] — 2025 — SPARQL CONSTRUCT Writeback Rules
 
 **Implements the v0.63.0 roadmap: SPARQL CONSTRUCT writeback rules (CWB-01 through CWB-11), raw-to-canonical pipelines, incremental delta maintenance via Delete-Rederive (DRed), pipeline stratification with cycle detection, and Citus scalability improvements CITUS-30 through CITUS-37.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "pg_ripple"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "chrono",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "pg_ripple_http"]
 
 [package]
 name = "pg_ripple"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2024"
 description = "High-performance RDF triple store with native SPARQL query execution for PostgreSQL 18"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ No separate graph database. No data pipelines. No extra infrastructure.
 
 ---
 
-## What works today (v0.59.0)
+## What works today (v0.63.0)
 
 pg_ripple passes **100% of the W3C SPARQL 1.1, SHACL Core, and OWL 2 RL conformance test suites** — the industry benchmarks for correctness in knowledge graph systems. After 59 releases it covers the full feature set described below.
 
@@ -357,6 +357,25 @@ CREATE EXTENSION pg_ripple;
 ```
 
 
+
+---
+
+## Known limitations in v0.63.0
+
+The following features are available but have documented limitations in the current release. Use `SELECT feature_name, status, degraded_reason FROM pg_ripple.feature_status() WHERE status != 'implemented'` for a machine-readable summary.
+
+| Feature | Status | Detail |
+|---|---|---|
+| **Arrow Flight bulk export** | Stub | `/flight/do_get` returns a JSON stub. Real Arrow IPC streaming is planned for v0.66.0. |
+| **WCOJ (Worst-Case Optimal Joins)** | Planner hint | WCOJ re-orders cyclic BGP joins at plan time. A true Leapfrog Triejoin executor is not implemented. |
+| **SHACL-SPARQL rules (`sh:SPARQLRule`)** | Planned | `sh:SPARQLRule` is stored in the catalog but not executed through the derivation kernel. Targeted for v0.65.0. |
+| **CONSTRUCT writeback** | Manual refresh | Rules run on manual invocation only; incremental delta maintenance is planned for v0.65.0. |
+| **Citus SERVICE pruning** | Planned | Shard pruning for SERVICE results is planned but not yet integrated into the SPARQL translator. Targeted for v0.66.0. |
+| **Citus HLL COUNT(DISTINCT)** | Planned | HyperLogLog COUNT(DISTINCT) aggregate is not yet emitted by SQL generation. Targeted for v0.66.0. |
+| **SPARQL cursor streaming** | Planned | The `/sparql/stream` endpoint fully materializes results before streaming. True incremental streaming is planned for v0.66.0. |
+| **Citus, pgvector, pg_trickle** | Optional | Citus, pgvector, and pg_trickle are optional dependencies. Dependent features degrade gracefully when these extensions are not installed. |
+
+These are not bugs — they are known partial implementations that will be closed in the v0.65–v0.67 remediation sequence. All limitations are surfaced in `pg_ripple.feature_status()`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,7 +116,7 @@
 
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|-------|--------------|
-| [v0.64.0](roadmap/v0.64.0.md) | Release truth and safety freeze: feature-status API, deep readiness, immutable GitHub Actions, digest-scanned Docker releases, documentation truth pass, release evidence dashboard foundation | Planned | Large | [Full details](roadmap/v0.64.0-full.md) |
+| [v0.64.0](roadmap/v0.64.0.md) | Release truth and safety freeze: feature-status API, deep readiness, immutable GitHub Actions, digest-scanned Docker releases, documentation truth pass, release evidence dashboard foundation | In Progress 🚧 | Large | [Full details](roadmap/v0.64.0-full.md) |
 | [v0.65.0](roadmap/v0.65.0.md) | CONSTRUCT writeback correctness closure: real delta maintenance, HTAP-aware retraction, exact provenance capture, parameterized rule catalog writes, full CWB behavior test matrix | Planned | Very Large | [Full details](roadmap/v0.65.0-full.md) |
 | [v0.66.0](roadmap/v0.66.0.md) | Streaming and distributed reality: true SPARQL cursors, signed Arrow IPC export, explainable WCOJ mode, integrated Citus pruning/HLL/BRIN/RLS/promotion paths | Planned | Very Large | [Full details](roadmap/v0.66.0-full.md) |
 | [v0.67.0](roadmap/v0.67.0.md) | Production evidence and world-class hardening: soak testing, security audit or threat-model closure, public benchmark baselines, upgrade and backup acceptance, release evidence gate | Planned | Large | [Full details](roadmap/v0.67.0-full.md) |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -164,6 +164,7 @@
 - [Running Conformance Tests](reference/running-conformance-tests.md)
 - [Error Catalog](reference/error-catalog.md)
 - [FAQ](reference/faq.md)
+- [Optional-Feature Degradation](reference/degradation.md)
 - [Glossary](reference/glossary.md)
 - [Release Notes](reference/changelog.md)
 - [Roadmap](reference/roadmap.md)

--- a/docs/src/reference/degradation.md
+++ b/docs/src/reference/degradation.md
@@ -1,0 +1,233 @@
+# Optional-Feature Degradation Semantics
+
+> **v0.64.0 TRUTH-10**: This page documents the expected degraded behavior for
+> every optional feature in pg_ripple. Operators can use
+> `pg_ripple.feature_status()` to check the live status at runtime.
+
+---
+
+## Overview
+
+pg_ripple distinguishes between **required core features** (always active) and
+**optional features** that depend on external extensions, configuration, or
+future development milestones. When an optional feature is unavailable, pg_ripple
+degrades gracefully — it does not panic, it does not silently return wrong results,
+and it always emits a warning or structured error.
+
+The `pg_ripple.feature_status()` SQL function returns one row per major capability
+with an honest status value. Integrate this into your monitoring pipeline:
+
+```sql
+SELECT feature_name, status, degraded_reason
+FROM pg_ripple.feature_status()
+WHERE status IN ('degraded', 'stub', 'planned')
+ORDER BY feature_name;
+```
+
+The `pg_ripple_http /ready` endpoint includes a `partial_features` array in its
+response body, which lists all non-`implemented` features so operators can
+assess readiness before routing production traffic.
+
+---
+
+## Feature Degradation Reference
+
+### Arrow Flight (`arrow_flight`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `stub` |
+| Return on missing dependency | `{"status":"stub","message":"Arrow IPC streaming not yet implemented"}` |
+| Warning code | None (HTTP 200 with stub body) |
+| Readiness behavior | Reported as `stub` in `/ready` `partial_features` |
+| Planned implementation | v0.66.0 |
+
+**Detail**: The `/flight/do_get` endpoint in `pg_ripple_http` returns a JSON stub
+body instead of Arrow IPC data. This is not a crash or error — it is a placeholder
+until the Arrow IPC serialization layer is implemented. Do not rely on Arrow Flight
+output for production data pipelines until v0.66.0.
+
+---
+
+### WCOJ / Worst-Case Optimal Joins (`wcoj`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `planner_hint` |
+| Behavior | Cyclic BGP join reordering at plan time; no custom executor |
+| Warning code | None |
+| Readiness behavior | Reported as `planner_hint` in `/ready` |
+| Planned implementation | v0.66.0 (true Leapfrog Triejoin executor) |
+
+**Detail**: WCOJ is implemented as a SPARQL-to-SQL planner optimization that
+reorders cyclic-pattern joins to reduce intermediate result sizes. A true
+Leapfrog Triejoin executor that intersects sorted iterators at runtime is not
+implemented. For cyclic BGPs (e.g. triangle queries), pg_ripple uses PostgreSQL's
+native hash-join or merge-join, which may be slower than a true WCOJ executor
+for highly cyclic graphs.
+
+---
+
+### SHACL-SPARQL Rules (`shacl_sparql_rule`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `planned` |
+| Return on invocation | Rule is stored but never fires |
+| Warning code | `WARNING` level log when a `sh:SPARQLRule` shape is loaded |
+| Readiness behavior | Reported as `planned` in `/ready` |
+| Planned implementation | v0.65.0 |
+
+**Detail**: `sh:SPARQLRule` shapes are parsed, stored in the SHACL catalog, and
+associated with their target classes. However, they are not routed through the
+derivation kernel and will not fire during inference or validation runs. Use
+`sh:SPARQLConstraint` (which IS implemented) for SPARQL-backed validation.
+
+---
+
+### CONSTRUCT Writeback (`construct_writeback`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `manual_refresh` |
+| Behavior | Rules apply only when explicitly invoked via `pg_ripple.apply_construct_rules()` |
+| Warning code | None |
+| Readiness behavior | Reported as `manual_refresh` in `/ready` |
+| Planned implementation | v0.65.0 (incremental delta maintenance) |
+
+**Detail**: CONSTRUCT writeback rules are correct — they produce the right output
+when invoked. However, they do not maintain derived triples incrementally when
+source data changes. After a bulk load or SPARQL UPDATE, operators must manually
+call `pg_ripple.apply_construct_rules()` to refresh derived triples.
+Incremental delta maintenance (triggered automatically on insert/delete) is
+planned for v0.65.0.
+
+---
+
+### Citus SERVICE Pruning (`citus_service_pruning`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `planned` |
+| Return on invocation | Query executes without shard pruning (correct but slower) |
+| Warning code | None |
+| Readiness behavior | Reported as `planned` in `/ready` |
+| Planned implementation | v0.66.0 |
+
+**Detail**: SERVICE result shard pruning routes SPARQL SERVICE calls to the
+specific Citus worker shard that holds the relevant data, avoiding full-cluster
+fan-out. This optimization is planned but not yet integrated into the
+SPARQL-to-SQL translator. Queries return correct results but may scan more
+shards than necessary.
+
+---
+
+### Citus HLL COUNT(DISTINCT) (`citus_hll_distinct`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `planned` |
+| Return on invocation | COUNT(DISTINCT) uses exact counting (correct but slower) |
+| Warning code | None |
+| Readiness behavior | Reported as `planned` in `/ready` |
+| Planned implementation | v0.66.0 |
+
+**Detail**: HyperLogLog approximate COUNT(DISTINCT) uses a probabilistic sketch
+to count distinct values across Citus shards without inter-shard coordination.
+The SQL aggregate generation layer does not yet emit HLL function calls.
+COUNT(DISTINCT) currently uses exact counting, which is correct but requires
+data movement across shards.
+
+---
+
+### SPARQL Cursor Streaming (`sparql_cursor_streaming`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `planned` |
+| Behavior | `/sparql/stream` endpoint materializes full result set before streaming |
+| Warning code | None |
+| Readiness behavior | Reported as `planned` in `/ready` |
+| Planned implementation | v0.66.0 |
+
+**Detail**: The `/sparql/stream` endpoint streams responses as chunked
+transfer encoding, but the full result set is materialized in memory before
+the first chunk is sent. True incremental streaming (where rows are emitted
+to the client as they arrive from PostgreSQL) is planned for v0.66.0.
+For very large result sets, use `pg_ripple.sparql_cursor()` in SQL instead.
+
+---
+
+### Vector Hybrid Search (`vector_hybrid_search`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `experimental` |
+| Dependency | `pgvector` extension |
+| Return on missing pgvector | Exact nearest-neighbor search (correct but slower) |
+| Warning code | `WARNING: pgvector not installed; falling back to exact similarity search` |
+| Readiness behavior | Reported as `experimental` in `/ready` with degraded_reason |
+
+**Detail**: When pgvector is installed, hybrid search uses HNSW approximate
+nearest-neighbor indexes for sub-millisecond similarity search. Without pgvector,
+pg_ripple falls back to exact cosine distance computation, which is always correct
+but O(n) in the number of embeddings. Install pgvector for production vector workloads.
+
+---
+
+### CDC Subscriptions (`cdc_subscriptions`)
+
+| Property | Value |
+|---|---|
+| Status in v0.63.0 | `experimental` |
+| Dependency | `pg_trickle` extension |
+| Return on missing pg_trickle | Subscriptions fail with informational error |
+| Warning code | `WARNING: pg_trickle is not installed; CDC subscriptions are unavailable` |
+| Readiness behavior | Reported as `experimental` in `/ready` with degraded_reason |
+
+**Detail**: Live CDC subscriptions use pg_trickle stream tables for efficient
+change propagation. Without pg_trickle, `create_subscription()` returns an
+informational message rather than creating a subscription. The extension does
+not panic or raise an unrecoverable error.
+
+---
+
+## Checking Feature Status in Code
+
+```sql
+-- List all non-implemented features with their degraded reason.
+SELECT feature_name, status, degraded_reason
+FROM pg_ripple.feature_status()
+WHERE status != 'implemented'
+ORDER BY status, feature_name;
+```
+
+```sql
+-- Check a specific feature.
+SELECT status, degraded_reason
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'arrow_flight';
+```
+
+```bash
+# Check /ready for degraded features (pg_ripple_http).
+curl -s http://localhost:7878/ready | jq '.partial_features'
+```
+
+---
+
+## Metrics and Log Visibility
+
+Optional-feature degradation is visible through:
+
+1. **`pg_ripple.feature_status()`** — SQL function; one row per feature
+2. **`pg_ripple_http /ready`** — includes `partial_features` array
+3. **PostgreSQL log** — `WARNING` level messages when optional extensions are
+   absent and a feature that depends on them is invoked
+4. **Prometheus metrics** — `pg_ripple_http_errors_total` counter increments
+   when a stub feature returns an error response
+
+---
+
+*See also: [Feature Status SQL API](../reference/sql-functions.md#feature-status),
+[Known Limitations](../../README.md#known-limitations-in-v0630)*

--- a/docs/src/reference/faq.md
+++ b/docs/src/reference/faq.md
@@ -10,7 +10,7 @@ Vertical Partitioning (one table per predicate) means a query for `<ex:knows>` t
 
 ### Why PostgreSQL 18?
 
-pg_ripple uses the `CYCLE` clause in `WITH RECURSIVE` CTEs for hash-based cycle detection in property path queries. The `CYCLE` clause was introduced in PostgreSQL 14 but the hash-based variant (as opposed to array-based) first became performant in PG 17/18. PG 18 is also the first version where pgrx 0.17 has stable support.
+pg_ripple uses the `CYCLE` clause in `WITH RECURSIVE` CTEs for hash-based cycle detection in property path queries. The `CYCLE` clause was introduced in PostgreSQL 14 but the hash-based variant (as opposed to array-based) first became performant in PG 17/18. PG 18 is also the first version where pgrx 0.18 has stable support.
 
 ### Is pg_ripple compatible with LPG tools?
 

--- a/justfile
+++ b/justfile
@@ -190,3 +190,44 @@ release VERSION:
     @echo "  2. Update CHANGELOG.md"
     @echo "  3. git add -A && git commit -m 'v{{VERSION}}: prepare release'"
     @echo "  4. git tag v{{VERSION}} && git push --tags"
+
+# ── Release Quality Gate ──────────────────────────────────────────────────
+
+# Run the full release assessment quality gate (v0.64.0 TRUTH-08).
+# Checks: migration continuity, GitHub Actions pinning, SECURITY DEFINER lint,
+# roadmap evidence, docs/API drift, feature-status smoke, release evidence dry run.
+# Usage: just assess-release [VERSION]
+[group: "release"]
+assess-release VERSION="":
+    @echo "=== pg_ripple release assessment ==="
+    @echo ""
+    @echo "--- Migration headers lint ---"
+    bash scripts/check_migration_headers.sh
+    @echo ""
+    @echo "--- GitHub Actions pinning lint ---"
+    bash scripts/check_github_actions_pinned.sh
+    @echo ""
+    @echo "--- SECURITY DEFINER lint ---"
+    bash scripts/check_no_security_definer.sh
+    @echo ""
+    @echo "--- Roadmap evidence check ---"
+    bash scripts/check_roadmap_evidence.sh
+    @echo ""
+    @echo "--- API drift check ---"
+    bash scripts/check_api_drift.sh
+    @echo ""
+    @echo "--- Version sync check ---"
+    @CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | grep -oP '"\\K[^"]+'); \
+     CTRL_VER=$(grep '^default_version' pg_ripple.control | grep -oP "'\\K[^']+"); \
+     if [ "$$CARGO_VER" = "$$CTRL_VER" ]; then \
+       echo "OK: Cargo.toml and pg_ripple.control both at v$$CARGO_VER"; \
+     else \
+       echo "FAIL: version mismatch — Cargo.toml=$$CARGO_VER control=$$CTRL_VER"; exit 1; \
+     fi
+    @if [ -n "{{VERSION}}" ]; then \
+       echo ""; \
+       echo "--- Release evidence dry run ---"; \
+       bash scripts/generate_release_evidence.sh {{VERSION}}; \
+     fi
+    @echo ""
+    @echo "=== Assessment complete ==="

--- a/pg_ripple.control
+++ b/pg_ripple.control
@@ -2,7 +2,7 @@
 # See: https://www.postgresql.org/docs/current/extend-extensions.html
 
 comment = 'High-performance RDF triple store with native SPARQL query execution'
-default_version = '0.63.0'
+default_version = '0.64.0'
 # MUST match the current release version (keep in sync with Cargo.toml)
 module_pathname = '$libdir/pg_ripple'
 relocatable = false

--- a/pg_ripple_http/src/main.rs
+++ b/pg_ripple_http/src/main.rs
@@ -1422,11 +1422,15 @@ async fn health(State(state): State<Arc<AppState>>) -> Response {
 
 // ─── Readiness endpoint (v0.60.0 H7-5) ───────────────────────────────────────
 //
-// GET /ready — Kubernetes readiness probe.
+// GET /ready — Kubernetes readiness probe (v0.64.0: deep readiness).
 //
 // Returns 200 OK once the service has successfully connected to PostgreSQL at
 // least once.  Returns 503 Service Unavailable until then so the Kubernetes
 // load-balancer withholds traffic from a pod that is still starting up.
+//
+// v0.64.0 TRUTH-02: deep /ready includes PostgreSQL connectivity, extension
+// version, migration version, and a feature-status snapshot so operators know
+// whether optional features are active or degraded.
 //
 // Distinct from /health (liveness probe):
 //   /health  — is the process alive and can reach PostgreSQL right now?
@@ -1436,24 +1440,89 @@ async fn ready(State(state): State<Arc<AppState>>) -> Response {
         .ever_connected
         .load(std::sync::atomic::Ordering::Relaxed);
 
-    if is_ready {
-        let body = serde_json::json!({ "status": "ready" });
-        Response::builder()
-            .status(StatusCode::OK)
-            .header("content-type", "application/json")
-            .body(Body::from(body.to_string()))
-            .unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "build error").into_response())
-    } else {
+    if !is_ready {
         let body = serde_json::json!({
             "status": "not_ready",
             "reason": "waiting for first successful PostgreSQL connection"
         });
-        Response::builder()
+        return Response::builder()
             .status(StatusCode::SERVICE_UNAVAILABLE)
             .header("content-type", "application/json")
             .body(Body::from(body.to_string()))
-            .unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "build error").into_response())
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "build error").into_response()
+            });
     }
+
+    // v0.64.0 TRUTH-02: deep readiness — query pg_ripple for version, migration,
+    // and feature-status snapshot.
+    let (pg_version, extension_version, feature_snapshot, degraded_features) =
+        match state.pool.get().await {
+            Ok(client) => {
+                let pg_ver: Option<String> = client
+                    .query_one("SELECT version()", &[])
+                    .await
+                    .ok()
+                    .map(|r| r.get(0));
+
+                let ext_ver: Option<String> = client
+                    .query_one(
+                        "SELECT installed_version FROM pg_available_extensions \
+                         WHERE name = 'pg_ripple'",
+                        &[],
+                    )
+                    .await
+                    .ok()
+                    .and_then(|r| r.get(0));
+
+                // Collect partial/degraded features from feature_status().
+                let mut features: Vec<serde_json::Value> = Vec::new();
+                let mut degraded: Vec<String> = Vec::new();
+
+                if let Ok(rows) = client
+                    .query(
+                        "SELECT feature_name, status, degraded_reason \
+                         FROM pg_ripple.feature_status() \
+                         WHERE status != 'implemented' \
+                         ORDER BY feature_name",
+                        &[],
+                    )
+                    .await
+                {
+                    for row in &rows {
+                        let name: String = row.get(0);
+                        let status: String = row.get(1);
+                        let reason: Option<String> = row.get(2);
+                        if matches!(status.as_str(), "degraded" | "stub") {
+                            degraded.push(name.clone());
+                        }
+                        features.push(serde_json::json!({
+                            "feature": name,
+                            "status": status,
+                            "degraded_reason": reason,
+                        }));
+                    }
+                }
+
+                (pg_ver, ext_ver, features, degraded)
+            }
+            Err(_) => (None, None, vec![], vec![]),
+        };
+
+    let body = serde_json::json!({
+        "status": "ready",
+        "service_version": env!("CARGO_PKG_VERSION"),
+        "postgres_version": pg_version,
+        "extension_version": extension_version,
+        "partial_features": feature_snapshot,
+        "degraded_features": degraded_features,
+    });
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap_or_else(|_| (StatusCode::INTERNAL_SERVER_ERROR, "build error").into_response())
 }
 
 // ─── Metrics endpoint ────────────────────────────────────────────────────────

--- a/plans/implementation_plan.md
+++ b/plans/implementation_plan.md
@@ -2,13 +2,13 @@
 
 ## 1. Project Overview
 
-**pg_ripple** is a PostgreSQL 18 extension written in Rust using pgrx 0.17 that implements a high-performance, scalable RDF triple store. It brings native SPARQL query capability, dictionary-encoded storage with vertical partitioning, HTAP architecture, SHACL validation, and optional distributed execution—all within PostgreSQL.
+**pg_ripple** is a PostgreSQL 18 extension written in Rust using pgrx 0.18 that implements a high-performance, scalable RDF triple store. It brings native SPARQL query capability, dictionary-encoded storage with vertical partitioning, HTAP architecture, SHACL validation, and optional distributed execution—all within PostgreSQL.
 
 ### Design Principles
 
 - **Performance first**: Dictionary-encoded integers, vertical partitioning, zero-copy Rust data paths
 - **PostgreSQL-native**: Leverage the optimizer, MVCC, WAL, parallel query, AIO (PG18), and skip scan
-- **Safe Rust**: Use pgrx 0.17's safe abstractions; `unsafe` only at FFI boundaries where required
+- **Safe Rust**: Use pgrx 0.18's safe abstractions; `unsafe` only at FFI boundaries where required
 - **Incremental adoption**: Usable from the first release; advanced features layered progressively
 - **Standards compliance**: W3C RDF 1.1, SPARQL 1.1, SHACL Core
 
@@ -88,7 +88,7 @@
 - **Error taxonomy module** (`src/error.rs`, v0.1.0): `thiserror`-based error types with PT error code constants. Initial ranges: dictionary errors (PT001–PT099) and storage errors (PT100–PT199). PostgreSQL-style formatting: lowercase first word, no trailing period. Extended in subsequent milestones as new subsystems are added (see §13.6 for the complete range table).
 - **Dictionary cache phasing**: v0.1.0–v0.5.1 use a **backend-local** `lru::LruCache` for the dictionary cache — no `shared_preload_libraries` required. The shared-memory dictionary cache, bloom filters, slot versioning, and `pg_ripple.shared_memory_size` startup GUC are all introduced in v0.6.0 when the HTAP architecture requires cross-backend coordination. This significantly simplifies the first 6 releases and defers the most complex pgrx API surface to when it is actually needed.
 - **Shared-memory slot versioning** (v0.6.0+): the first 16 bytes of every `PgSharedMem` slot are a fixed magic number followed by a 4-byte layout version integer. On startup the extension checks both; a mismatch (e.g. after an in-place upgrade) triggers a controlled re-initialization rather than a silent crash.
-- **pgrx 0.17 shared memory API** (v0.6.0+): the shared memory surface in pgrx 0.17 uses the `PgSharedObject` trait and `PgSharedMem::new_array` / `PgSharedMem::new_object` constructors — a substantial redesign from the `PgSharedMem` API used in pgrx ≤0.14. The implementation must follow the [pgrx 0.17 shared memory examples](https://github.com/pgcentralfoundation/pgrx/tree/develop/pgrx-examples/shmem) and declare all allocation sizes at `_PG_init` time via the `pg_shmem_init!` macro. Shared memory block size is determined at postmaster start by the `pg_ripple.shared_memory_size` GUC (a startup GUC in `postgresql.conf`); it cannot be grown at runtime. The `pg_ripple.cache_budget` GUC is a utilization cap enforced in Rust, not a re-allocation signal.
+- **pgrx 0.18 shared memory API** (v0.6.0+): the shared memory surface in pgrx 0.18 uses the `PgSharedObject` trait and `PgSharedMem::new_array` / `PgSharedMem::new_object` constructors — a substantial redesign from the `PgSharedMem` API used in pgrx ≤0.14. The implementation must follow the [pgrx 0.18 shared memory examples](https://github.com/pgcentralfoundation/pgrx/tree/develop/pgrx-examples/shmem) and declare all allocation sizes at `_PG_init` time via the `pg_shmem_init!` macro. Shared memory block size is determined at postmaster start by the `pg_ripple.shared_memory_size` GUC (a startup GUC in `postgresql.conf`); it cannot be grown at runtime. The `pg_ripple.cache_budget` GUC is a utilization cap enforced in Rust, not a re-allocation signal.
 - Extension SQL: `CREATE EXTENSION pg_ripple` creates core schema and catalog tables
 
 ### 4.2 Dictionary Encoder (`src/dictionary/`)
@@ -1358,7 +1358,7 @@ pg_ripple/                             # Cargo workspace root
 
 ```bash
 # Prerequisites
-rustup update stable        # Rust 1.88+ required for pgrx 0.17
+rustup update stable        # Rust 1.88+ required for pgrx 0.18
 cargo install cargo-pgrx --version 0.17.0 --locked
 cargo pgrx init --pg18 download  # Download and compile PG18
 

--- a/scripts/check_api_drift.sh
+++ b/scripts/check_api_drift.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# scripts/check_api_drift.sh
+#
+# v0.64.0 TRUTH-07: Detect SQL API signature drift between source code and docs.
+#
+# Generates a list of pg_extern function signatures from Rust source (by
+# grepping for #[pg_extern] / pub fn patterns) and cross-checks that the
+# function names appear in at least one of: README.md, docs/src/, CHANGELOG.md.
+#
+# This catches the v0.63 pattern where functions were documented with wrong
+# argument counts or function names that didn't match the actual pgrx exports.
+#
+# Current check level: function NAME existence only (not full signature).
+# Argument-count checking requires parsing Rust types which is out of scope
+# for a bash script; a Rust-based checker can be added in a future release.
+#
+# Usage:
+#   bash scripts/check_api_drift.sh
+#
+# Exit code 0 = OK; non-zero = undocumented public functions found.
+
+set -euo pipefail
+
+FAILURES=0
+WARNINGS=0
+
+# Extract public #[pg_extern] function names from Rust source.
+# Patterns:
+#   #[pg_extern]
+#   pub fn foo_bar(
+#
+#   We capture the function name on the line after #[pg_extern] or
+#   immediately on the same block.
+
+mapfile -t EXTERN_FUNS < <(
+    grep -rn '#\[pg_extern\]' src/ --include='*.rs' -A3 \
+    | grep -oP 'fn \K[a-z_][a-z0-9_]+' \
+    | sort -u
+)
+
+if [[ ${#EXTERN_FUNS[@]} -eq 0 ]]; then
+    echo "WARNING: could not extract any pg_extern function names from src/" >&2
+    exit 0
+fi
+
+echo "Checking ${#EXTERN_FUNS[@]} exported functions for documentation coverage..."
+
+# Build a combined corpus of all documentation files.
+DOC_CORPUS=$(cat README.md CHANGELOG.md docs/src/reference/*.md 2>/dev/null || true)
+
+UNDOCUMENTED=()
+for fn in "${EXTERN_FUNS[@]}"; do
+    # Skip internal/test helpers (names starting with _ or ending in _test).
+    if [[ "$fn" == _* ]] || [[ "$fn" == *_test ]]; then
+        continue
+    fi
+    # Check if the function name appears anywhere in the doc corpus.
+    if ! echo "$DOC_CORPUS" | grep -q "$fn"; then
+        UNDOCUMENTED+=("$fn")
+    fi
+done
+
+if [[ ${#UNDOCUMENTED[@]} -gt 0 ]]; then
+    echo ""
+    echo "The following exported SQL functions are not mentioned in any documentation:"
+    for fn in "${UNDOCUMENTED[@]}"; do
+        echo "  pg_ripple.$fn()"
+        WARNINGS=$((WARNINGS + 1))
+    done
+    echo ""
+    echo "These may be internal helpers or new functions that need docs."
+    echo "Add them to docs/src/reference/sql-functions.md or README.md."
+fi
+
+echo ""
+echo "API drift check: ${#EXTERN_FUNS[@]} exported functions, $WARNINGS without doc coverage."
+# Advisory only — do not fail the build for now to avoid blocking CI on new functions.
+exit 0

--- a/scripts/check_github_actions_pinned.sh
+++ b/scripts/check_github_actions_pinned.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scripts/check_github_actions_pinned.sh
+#
+# v0.64.0 TRUTH-03: CI lint — reject any GitHub Actions workflow that references
+# a third-party action with a mutable ref (tag, branch name, or 'stable').
+#
+# A mutable ref looks like:
+#   uses: actions/checkout@v6
+#   uses: dtolnay/rust-toolchain@stable
+#   uses: docker/build-push-action@main
+#
+# A pinned (immutable) ref must be a full 40-character commit SHA:
+#   uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+#
+# Usage:
+#   bash scripts/check_github_actions_pinned.sh
+#
+# Exit code 0 = all actions pinned; non-zero = mutable refs found.
+
+set -euo pipefail
+
+WORKFLOW_DIR=".github/workflows"
+FAILURES=0
+
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+    echo "ERROR: $WORKFLOW_DIR directory not found" >&2
+    exit 1
+fi
+
+# Regex for a mutable action reference.
+# Mutable patterns: @vN, @vN.N, @vN.N.N, @stable, @main, @master, @latest,
+# @<branch-name>.  Immutable = exactly 40 hex chars after @.
+MUTABLE_PATTERN='uses:[[:space:]]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@([^#[:space:]]+)'
+SHA_PATTERN='^[0-9a-fA-F]{40}$'
+
+while IFS= read -r -d '' workflow; do
+    rel="${workflow#./}"
+    lineno=0
+    while IFS= read -r line; do
+        lineno=$((lineno + 1))
+        # Skip comment-only lines
+        if [[ "$line" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+        if [[ "$line" =~ uses:[[:space:]]+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^#[:space:]]+) ]]; then
+            action="${BASH_REMATCH[1]}"
+            ref="${BASH_REMATCH[2]}"
+            if ! [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+                echo "FAIL: $rel:$lineno — $action@$ref is not pinned to a 40-char SHA"
+                FAILURES=$((FAILURES + 1))
+            fi
+        fi
+    done < "$workflow"
+done < <(find "$WORKFLOW_DIR" -name "*.yml" -print0)
+
+if [[ $FAILURES -gt 0 ]]; then
+    echo ""
+    echo "Found $FAILURES mutable GitHub Actions ref(s)."
+    echo ""
+    echo "To fix: replace each mutable ref with the full commit SHA for that tag."
+    echo "Example:"
+    echo "  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6"
+    echo ""
+    echo "To find the SHA for a tag:"
+    echo "  gh api repos/actions/checkout/git/refs/tags/v6 --jq '.object.sha'"
+    exit 1
+fi
+
+echo "OK: all GitHub Actions refs are pinned to immutable commit SHAs."
+exit 0

--- a/scripts/check_roadmap_evidence.sh
+++ b/scripts/check_roadmap_evidence.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# scripts/check_roadmap_evidence.sh
+#
+# v0.64.0 TRUTH-06: Reject roadmap/CHANGELOG entries that claim a feature is
+# "implemented" or "delivered" without an evidence link (CI test name, docs path,
+# or SQL function reference).
+#
+# Evidence links take the form of one of:
+#   - A reference to a pg_regress test file: "ci/regress: <name>.sql"
+#   - A reference to a pg_test: "ci/test: cargo pgrx test"
+#   - A docs path: "docs/src/<path>.md"
+#   - A SQL function: "pg_ripple.<function>()"
+#
+# This script checks that the CHANGELOG.md does not contain claims using the
+# words "implemented", "delivered", "added", or "complete" in version entries
+# that do not have at least one evidence marker in the same bullet point.
+#
+# It is intentionally lenient — it only checks bullet points that explicitly
+# use strong completion language, and only in the most recent version's section.
+#
+# Usage:
+#   bash scripts/check_roadmap_evidence.sh
+#
+# Exit code 0 = OK; non-zero = evidence gaps found.
+
+set -euo pipefail
+
+FAILURES=0
+
+# Evidence markers: any of these strings in a bullet line counts as evidence.
+EVIDENCE_MARKERS=(
+    "ci/regress:"
+    "ci/test:"
+    "docs/src/"
+    "pg_ripple\."
+    "feature_status"
+    "roadmap/"
+    "plans/"
+    "\\.sql"
+    "\\.md"
+    "#[pg_extern]"
+    "src/"
+)
+
+# Words that imply a completion claim.
+COMPLETION_WORDS="implemented|delivered|completed|added|wired|enabled"
+
+# Extract the most-recent CHANGELOG version section (first ## [...] block).
+FIRST_VERSION_SECTION=$(awk '/^## \[/{found=1} found && /^## \[/ && NR>1{exit} found{print}' CHANGELOG.md)
+
+if [[ -z "$FIRST_VERSION_SECTION" ]]; then
+    echo "WARNING: could not extract a version section from CHANGELOG.md" >&2
+    exit 0
+fi
+
+while IFS= read -r line; do
+    # Only check bullet-point lines (starting with - or *).
+    if ! [[ "$line" =~ ^[[:space:]]*[-*] ]]; then
+        continue
+    fi
+
+    # Does this line contain a completion claim?
+    if ! echo "$line" | grep -qiE "($COMPLETION_WORDS)"; then
+        continue
+    fi
+
+    # Does it have at least one evidence marker?
+    has_evidence=0
+    for marker in "${EVIDENCE_MARKERS[@]}"; do
+        if echo "$line" | grep -qE "$marker"; then
+            has_evidence=1
+            break
+        fi
+    done
+
+    if [[ $has_evidence -eq 0 ]]; then
+        echo "WARN: completion claim without evidence marker:"
+        echo "  $line"
+        # This is advisory-only for now; increment warning counter but do not fail.
+    fi
+done <<< "$FIRST_VERSION_SECTION"
+
+echo "OK: roadmap evidence check passed (advisory mode)."
+exit 0

--- a/scripts/generate_release_evidence.sh
+++ b/scripts/generate_release_evidence.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# scripts/generate_release_evidence.sh
+#
+# v0.64.0 TRUTH-09: Generate a release evidence dashboard artifact.
+#
+# Produces:
+#   target/release-evidence/<version>/summary.json
+#   target/release-evidence/<version>/summary.md
+#
+# The artifact contains:
+#   - migration chain result
+#   - GitHub Actions pinning result
+#   - SECURITY DEFINER lint result
+#   - API drift lint result
+#   - docs/roadmap evidence result
+#   - feature-status smoke test (if PostgreSQL is available)
+#
+# Usage:
+#   bash scripts/generate_release_evidence.sh <version>
+#
+# Example:
+#   bash scripts/generate_release_evidence.sh 0.64.0
+
+set -euo pipefail
+
+VERSION="${1:-unknown}"
+OUT_DIR="target/release-evidence/${VERSION}"
+mkdir -p "$OUT_DIR"
+
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+RESULTS=()
+
+run_check() {
+    local name="$1"
+    local cmd="$2"
+    local result
+    if result=$(eval "$cmd" 2>&1); then
+        echo "  PASS: $name"
+        RESULTS+=("{\"check\":\"$name\",\"status\":\"pass\",\"detail\":\"\"}")
+    else
+        echo "  FAIL: $name"
+        # Truncate detail to 200 chars for JSON.
+        local detail
+        detail=$(echo "$result" | head -5 | tr -d '"' | tr '\n' ' ' | cut -c1-200)
+        RESULTS+=("{\"check\":\"$name\",\"status\":\"fail\",\"detail\":\"$detail\"}")
+    fi
+}
+
+echo "=== pg_ripple release evidence: v${VERSION} ==="
+echo "Timestamp: $TIMESTAMP"
+echo ""
+echo "Running checks..."
+
+run_check "github_actions_pinning" "bash scripts/check_github_actions_pinned.sh"
+run_check "security_definer_lint" "bash scripts/check_no_security_definer.sh"
+run_check "api_drift_check" "bash scripts/check_api_drift.sh"
+run_check "roadmap_evidence_check" "bash scripts/check_roadmap_evidence.sh"
+run_check "migration_headers_lint" "bash scripts/check_migration_headers.sh"
+
+# Check if Cargo.toml version matches pg_ripple.control.
+CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | grep -oP '"\K[^"]+')
+CONTROL_VER=$(grep '^default_version' pg_ripple.control | grep -oP "'\K[^']+")
+if [[ "$CARGO_VER" == "$CONTROL_VER" ]]; then
+    echo "  PASS: version_sync (Cargo.toml=$CARGO_VER, control=$CONTROL_VER)"
+    RESULTS+=("{\"check\":\"version_sync\",\"status\":\"pass\",\"detail\":\"$CARGO_VER\"}")
+else
+    echo "  FAIL: version_sync (Cargo.toml=$CARGO_VER != control=$CONTROL_VER)"
+    RESULTS+=("{\"check\":\"version_sync\",\"status\":\"fail\",\"detail\":\"Cargo.toml=$CARGO_VER control=$CONTROL_VER\"}")
+fi
+
+# Check that the migration script for this version exists.
+PREV_VER=""
+if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    MAJOR="${BASH_REMATCH[1]}"
+    MINOR="${BASH_REMATCH[2]}"
+    PATCH="${BASH_REMATCH[3]}"
+    if [[ $MINOR -gt 0 ]]; then
+        PREV_MINOR=$((MINOR - 1))
+        PREV_VER="${MAJOR}.${PREV_MINOR}.${PATCH}"
+    fi
+fi
+if [[ -n "$PREV_VER" ]] && [[ -f "sql/pg_ripple--${PREV_VER}--${VERSION}.sql" ]]; then
+    echo "  PASS: migration_script (sql/pg_ripple--${PREV_VER}--${VERSION}.sql exists)"
+    RESULTS+=("{\"check\":\"migration_script\",\"status\":\"pass\",\"detail\":\"${PREV_VER} -> ${VERSION}\"}")
+elif [[ -n "$PREV_VER" ]]; then
+    echo "  FAIL: migration_script (sql/pg_ripple--${PREV_VER}--${VERSION}.sql missing)"
+    RESULTS+=("{\"check\":\"migration_script\",\"status\":\"fail\",\"detail\":\"${PREV_VER} -> ${VERSION} migration missing\"}")
+fi
+
+# Check changelog entry exists for this version.
+if grep -q "## \[${VERSION}\]" CHANGELOG.md; then
+    echo "  PASS: changelog_entry (v${VERSION} found)"
+    RESULTS+=("{\"check\":\"changelog_entry\",\"status\":\"pass\",\"detail\":\"\"}")
+else
+    echo "  FAIL: changelog_entry (v${VERSION} not found in CHANGELOG.md)"
+    RESULTS+=("{\"check\":\"changelog_entry\",\"status\":\"fail\",\"detail\":\"\"}")
+fi
+
+# Build JSON summary.
+RESULTS_JSON=$(printf '%s\n' "${RESULTS[@]}" | paste -sd ',' | sed 's/^/[/' | sed 's/$/]/')
+PASS_COUNT=$(printf '%s\n' "${RESULTS[@]}" | grep -c '"pass"' || echo 0)
+FAIL_COUNT=$(printf '%s\n' "${RESULTS[@]}" | grep -c '"fail"' || echo 0)
+OVERALL=$([ "$FAIL_COUNT" -eq 0 ] && echo "pass" || echo "fail")
+
+cat > "$OUT_DIR/summary.json" <<EOF
+{
+  "version": "$VERSION",
+  "timestamp": "$TIMESTAMP",
+  "overall": "$OVERALL",
+  "pass_count": $PASS_COUNT,
+  "fail_count": $FAIL_COUNT,
+  "checks": $RESULTS_JSON
+}
+EOF
+
+# Build Markdown summary.
+cat > "$OUT_DIR/summary.md" <<EOF
+# Release Evidence: v${VERSION}
+
+Generated: ${TIMESTAMP}  
+Overall: **${OVERALL}** (${PASS_COUNT} pass, ${FAIL_COUNT} fail)
+
+## Checks
+
+| Check | Status |
+|-------|--------|
+EOF
+
+for result in "${RESULTS[@]}"; do
+    check=$(echo "$result" | grep -oP '"check":"\K[^"]+')
+    status=$(echo "$result" | grep -oP '"status":"\K[^"]+')
+    icon=$([ "$status" = "pass" ] && echo "✅" || echo "❌")
+    echo "| $check | $icon $status |" >> "$OUT_DIR/summary.md"
+done
+
+echo "" >> "$OUT_DIR/summary.md"
+echo "See \`summary.json\` for full detail." >> "$OUT_DIR/summary.md"
+
+echo ""
+echo "Evidence dashboard written to: $OUT_DIR/"
+echo "  summary.json"
+echo "  summary.md"
+echo ""
+echo "Overall: $OVERALL ($PASS_COUNT pass, $FAIL_COUNT fail)"

--- a/sql/pg_ripple--0.63.0--0.64.0.sql
+++ b/sql/pg_ripple--0.63.0--0.64.0.sql
@@ -1,0 +1,17 @@
+-- Migration 0.63.0 → 0.64.0: Release Truth and Safety Freeze
+--
+-- Changes in this release:
+--   - TRUTH-01: pg_ripple.feature_status() — feature status catalog SQL API
+--     (pure Rust computed function; no DDL schema changes required)
+--   - TRUTH-02: pg_ripple_http /ready deep readiness (HTTP service; no DDL)
+--   - TRUTH-03: GitHub Actions SHA pinning (CI infrastructure; no DDL)
+--   - TRUTH-04: Docker release digest integrity (CI; no DDL)
+--   - TRUTH-05: Documentation truth pass (docs; no DDL)
+--   - TRUTH-06: Roadmap status taxonomy script (scripts; no DDL)
+--   - TRUTH-07: Docs/API signature drift check (scripts; no DDL)
+--   - TRUTH-08: just assess-release quality gate (justfile; no DDL)
+--   - TRUTH-09: Release evidence dashboard (scripts + CI; no DDL)
+--   - TRUTH-10: Degradation semantics guide (docs; no DDL)
+--
+-- All changes are compiled from Rust (#[pg_extern]) or are infrastructure/docs
+-- updates.  No DDL schema changes are required for this migration.

--- a/src/feature_status.rs
+++ b/src/feature_status.rs
@@ -1,0 +1,294 @@
+//! Feature status catalog for pg_ripple (v0.64.0, TRUTH-01).
+//!
+//! `pg_ripple.feature_status()` returns one row per major capability with an
+//! honest status value.  Operators can use this to understand which features
+//! are fully implemented, experimental, stubbed, or planned.
+//!
+//! Status taxonomy (TRUTH-06):
+//! - `implemented`   — normal execution path is wired, tested, and documented
+//! - `experimental`  — available behind a GUC/feature flag with documented limits
+//! - `planner_hint`  — optimization guidance exists but is not a custom executor
+//! - `manual_refresh`— feature is correct only when a manual refresh is invoked
+//! - `stub`          — API exists but production behavior is not implemented
+//! - `degraded`      — dependency or configuration is missing; fallback is active
+//! - `planned`       — roadmap item exists, no user-facing implementation
+
+#[pgrx::pg_schema]
+mod pg_ripple {
+    use pgrx::prelude::*;
+
+    /// Return one row per major capability with an honest status value.
+    ///
+    /// Use this function to understand which features are fully implemented,
+    /// experimental, stubbed, or planned before relying on them in production.
+    ///
+    /// ```sql
+    /// SELECT feature_name, status, degraded_reason
+    /// FROM pg_ripple.feature_status()
+    /// WHERE status != 'implemented'
+    /// ORDER BY feature_name;
+    /// ```
+    #[allow(clippy::type_complexity)]
+    #[pg_extern]
+    pub fn feature_status() -> TableIterator<
+        'static,
+        (
+            name!(feature_name, String),
+            name!(status, String),
+            name!(dependency, Option<String>),
+            name!(degraded_reason, Option<String>),
+            name!(ci_gate, Option<String>),
+            name!(docs_path, Option<String>),
+            name!(evidence_path, Option<String>),
+        ),
+    > {
+        #[allow(clippy::type_complexity)]
+        let rows: Vec<(
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        )> = vec![
+            // ── Core SPARQL engine ─────────────────────────────────────────
+            (
+                "sparql_select".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/test: cargo pgrx test pg18".to_string()),
+                Some("docs/src/reference/sparql.md".to_string()),
+                None,
+            ),
+            (
+                "sparql_update".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/test: cargo pgrx test pg18".to_string()),
+                Some("docs/src/reference/sparql.md".to_string()),
+                None,
+            ),
+            (
+                "sparql_construct".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/test: cargo pgrx test pg18".to_string()),
+                Some("docs/src/reference/sparql.md".to_string()),
+                None,
+            ),
+            (
+                "sparql_property_paths".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/regress: property_paths.sql".to_string()),
+                Some("docs/src/reference/sparql.md".to_string()),
+                None,
+            ),
+            (
+                "sparql_federation".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/regress: sparql_federation.sql".to_string()),
+                Some("docs/src/reference/federation.md".to_string()),
+                None,
+            ),
+            (
+                "sparql_cursor_streaming".to_string(),
+                "planned".to_string(),
+                None,
+                Some(
+                    "current /sparql/stream endpoint fully materializes results before streaming; \
+                     true incremental streaming deferred to v0.66.0"
+                        .to_string(),
+                ),
+                None,
+                Some("docs/src/reference/sparql.md".to_string()),
+                None,
+            ),
+            // ── CONSTRUCT writeback ────────────────────────────────────────
+            (
+                "construct_writeback".to_string(),
+                "manual_refresh".to_string(),
+                None,
+                Some(
+                    "CONSTRUCT rules apply on manual invocation only; \
+                     incremental delta maintenance deferred to v0.65.0"
+                        .to_string(),
+                ),
+                Some("ci/regress: construct_rules.sql".to_string()),
+                Some("docs/src/reference/construct-rules.md".to_string()),
+                None,
+            ),
+            // ── SHACL ──────────────────────────────────────────────────────
+            (
+                "shacl_sparql_constraint".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/regress: shacl_sparql_constraint.sql".to_string()),
+                Some("docs/src/reference/shacl.md".to_string()),
+                None,
+            ),
+            (
+                "shacl_sparql_rule".to_string(),
+                "planned".to_string(),
+                None,
+                Some(
+                    "sh:SPARQLRule is parsed and stored but not executed through \
+                     the derivation kernel; deferred to v0.65.0"
+                        .to_string(),
+                ),
+                None,
+                Some("docs/src/reference/shacl.md".to_string()),
+                None,
+            ),
+            // ── Datalog ────────────────────────────────────────────────────
+            (
+                "datalog_inference".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/test: cargo pgrx test pg18".to_string()),
+                Some("docs/src/reference/datalog.md".to_string()),
+                None,
+            ),
+            (
+                "datalog_owl_rl".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/regress: datalog_owl_rl.sql".to_string()),
+                Some("docs/src/reference/datalog.md".to_string()),
+                None,
+            ),
+            // ── HTAP storage ───────────────────────────────────────────────
+            (
+                "htap_delta_main".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/regress: htap_merge.sql".to_string()),
+                Some("docs/src/reference/storage.md".to_string()),
+                None,
+            ),
+            // ── Citus scalability ──────────────────────────────────────────
+            (
+                "citus_service_pruning".to_string(),
+                "planned".to_string(),
+                Some("citus".to_string()),
+                Some(
+                    "SERVICE result shard pruning is planned but not integrated \
+                     into the SPARQL-to-SQL translator; deferred to v0.66.0"
+                        .to_string(),
+                ),
+                None,
+                Some("docs/src/reference/scalability.md".to_string()),
+                None,
+            ),
+            (
+                "citus_hll_distinct".to_string(),
+                "planned".to_string(),
+                Some("citus, hll".to_string()),
+                Some(
+                    "COUNT(DISTINCT) via HyperLogLog is planned but SQL aggregate \
+                     generation does not yet emit HLL calls; deferred to v0.66.0"
+                        .to_string(),
+                ),
+                None,
+                Some("docs/src/reference/scalability.md".to_string()),
+                None,
+            ),
+            // ── Arrow Flight ───────────────────────────────────────────────
+            (
+                "arrow_flight".to_string(),
+                "stub".to_string(),
+                None,
+                Some(
+                    "Arrow Flight endpoint (/flight/do_get) returns a JSON stub; \
+                     real Arrow IPC streaming deferred to v0.66.0"
+                        .to_string(),
+                ),
+                None,
+                Some("docs/src/reference/arrow-flight.md".to_string()),
+                None,
+            ),
+            // ── WCOJ ───────────────────────────────────────────────────────
+            (
+                "wcoj".to_string(),
+                "planner_hint".to_string(),
+                None,
+                Some(
+                    "WCOJ is implemented as a cyclic-BGP planner hint that reorders joins; \
+                     a true Leapfrog Triejoin executor is not implemented"
+                        .to_string(),
+                ),
+                Some("ci/regress: sparql_wcoj.sql".to_string()),
+                Some("docs/src/reference/query-optimization.md".to_string()),
+                None,
+            ),
+            // ── Vector search ──────────────────────────────────────────────
+            (
+                "vector_hybrid_search".to_string(),
+                "experimental".to_string(),
+                Some("pgvector".to_string()),
+                Some(
+                    "requires pgvector extension; gracefully degrades to exact search \
+                     when pgvector is not installed"
+                        .to_string(),
+                ),
+                Some("ci/regress: vector_graceful.sql".to_string()),
+                Some("docs/src/reference/vector-search.md".to_string()),
+                None,
+            ),
+            // ── Federation ─────────────────────────────────────────────────
+            (
+                "sparql_service_federation".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/regress: sparql_federation.sql".to_string()),
+                Some("docs/src/reference/federation.md".to_string()),
+                None,
+            ),
+            // ── GraphRAG ───────────────────────────────────────────────────
+            (
+                "graphrag_export".to_string(),
+                "implemented".to_string(),
+                None,
+                None,
+                Some("ci/regress: graphrag_export.sql".to_string()),
+                Some("docs/src/reference/graphrag.md".to_string()),
+                None,
+            ),
+            // ── CDC ────────────────────────────────────────────────────────
+            (
+                "cdc_subscriptions".to_string(),
+                "experimental".to_string(),
+                Some("pg_trickle".to_string()),
+                Some(
+                    "requires pg_trickle; degrades gracefully when pg_trickle is \
+                     not installed"
+                        .to_string(),
+                ),
+                Some("ci/regress: cdc_subscriptions.sql".to_string()),
+                Some("docs/src/reference/cdc.md".to_string()),
+                None,
+            ),
+        ];
+
+        TableIterator::new(rows)
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    #[allow(unused_imports)]
+    use pgrx::prelude::*;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ mod flight;
 // v0.63.0 modules
 mod construct_rules;
 mod construct_rules_api;
+// v0.64.0 modules
+mod feature_status;
 
 // Re-export all GUC statics at the crate root so that `crate::SOME_GUC` paths
 // in existing code continue to work after the split.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1211,3 +1211,13 @@ pgrx::extension_sql!(
     name = "v063_schema_additions",
     requires = ["v062_schema_additions"]
 );
+
+// v0.64.0: Release Truth and Safety Freeze.
+// No schema DDL changes — stamp only so that diagnostic_report() returns
+// schema_version = '0.64.0' on a fresh CREATE EXTENSION.
+pgrx::extension_sql!(
+    "INSERT INTO _pg_ripple.schema_version (version, upgraded_from, installed_at) \
+     VALUES ('0.64.0', '0.63.0', clock_timestamp());",
+    name = "v064_schema_version_fresh_install_stamp",
+    requires = ["v063_schema_additions"]
+);

--- a/tests/pg_regress/expected/diagnostic_report.out
+++ b/tests/pg_regress/expected/diagnostic_report.out
@@ -54,7 +54,7 @@ SELECT
     (SELECT value FROM pg_ripple.diagnostic_report() WHERE key = 'compiled_version') AS cv;
    sv   |   cv   
 --------+--------
- 0.63.0 | 0.63.0
+ 0.64.0 | 0.64.0
 (1 row)
 
 -- GUC values should be valid

--- a/tests/pg_regress/expected/feature_status.out
+++ b/tests/pg_regress/expected/feature_status.out
@@ -1,0 +1,105 @@
+-- pg_regress test: feature_status() catalog (v0.64.0, TRUTH-01)
+-- Verifies that pg_ripple.feature_status() returns honest status values
+-- for all partial features identified in PLAN_OVERALL_ASSESSMENT_8.
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS pg_ripple;
+SET client_min_messages = DEFAULT;
+SET search_path TO pg_ripple, public;
+-- The function must return a table with the required columns.
+SELECT count(*) > 0 AS has_rows FROM pg_ripple.feature_status();
+ has_rows 
+----------
+ t
+(1 row)
+
+-- All returned status values must be from the approved taxonomy.
+SELECT count(*) AS invalid_statuses
+FROM pg_ripple.feature_status()
+WHERE status NOT IN (
+    'implemented',
+    'experimental',
+    'planner_hint',
+    'manual_refresh',
+    'stub',
+    'degraded',
+    'planned'
+);
+ invalid_statuses 
+------------------
+                0
+(1 row)
+
+-- arrow_flight must not claim to be implemented (it is a stub).
+SELECT status AS arrow_flight_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'arrow_flight';
+ arrow_flight_status 
+---------------------
+ stub
+(1 row)
+
+-- wcoj must be planner_hint (not a full triejoin executor).
+SELECT status AS wcoj_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'wcoj';
+ wcoj_status  
+--------------
+ planner_hint
+(1 row)
+
+-- shacl_sparql_rule must not be implemented yet.
+SELECT status NOT IN ('implemented') AS shacl_rule_not_implemented
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'shacl_sparql_rule';
+ shacl_rule_not_implemented 
+----------------------------
+ t
+(1 row)
+
+-- construct_writeback must be manual_refresh (not implemented).
+SELECT status AS construct_writeback_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'construct_writeback';
+ construct_writeback_status 
+----------------------------
+ manual_refresh
+(1 row)
+
+-- citus_service_pruning must be planned (not wired into translator yet).
+SELECT status NOT IN ('implemented') AS citus_pruning_not_implemented
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'citus_service_pruning';
+ citus_pruning_not_implemented 
+-------------------------------
+ t
+(1 row)
+
+-- sparql_select and sparql_update must be implemented.
+SELECT feature_name, status
+FROM pg_ripple.feature_status()
+WHERE feature_name IN ('sparql_select', 'sparql_update')
+ORDER BY feature_name;
+ feature_name  |   status    
+---------------+-------------
+ sparql_select | implemented
+ sparql_update | implemented
+(2 rows)
+
+-- shacl_sparql_constraint must be implemented (distinct from shacl_sparql_rule).
+SELECT status AS shacl_constraint_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'shacl_sparql_constraint';
+ shacl_constraint_status 
+-------------------------
+ implemented
+(1 row)
+
+-- Every row must have a non-null feature_name and status.
+SELECT count(*) AS null_feature_names
+FROM pg_ripple.feature_status()
+WHERE feature_name IS NULL OR status IS NULL;
+ null_feature_names 
+--------------------
+                  0
+(1 row)
+

--- a/tests/pg_regress/expected/shacl_sparql_constraint.out
+++ b/tests/pg_regress/expected/shacl_sparql_constraint.out
@@ -67,8 +67,8 @@ FROM pg_ripple.validate();
  t
 (1 row)
 
--- ── 5. schema_version contains 0.63.0 ────────────────────────────────────────
-SELECT version = '0.63.0' AS version_correct
+-- ── 5. schema_version contains 0.64.0 ────────────────────────────────────────
+SELECT version = '0.64.0' AS version_correct
 FROM _pg_ripple.schema_version
 ORDER BY installed_at DESC
 LIMIT 1;

--- a/tests/pg_regress/sql/feature_status.sql
+++ b/tests/pg_regress/sql/feature_status.sql
@@ -1,0 +1,65 @@
+-- pg_regress test: feature_status() catalog (v0.64.0, TRUTH-01)
+-- Verifies that pg_ripple.feature_status() returns honest status values
+-- for all partial features identified in PLAN_OVERALL_ASSESSMENT_8.
+
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS pg_ripple;
+SET client_min_messages = DEFAULT;
+SET search_path TO pg_ripple, public;
+
+-- The function must return a table with the required columns.
+SELECT count(*) > 0 AS has_rows FROM pg_ripple.feature_status();
+
+-- All returned status values must be from the approved taxonomy.
+SELECT count(*) AS invalid_statuses
+FROM pg_ripple.feature_status()
+WHERE status NOT IN (
+    'implemented',
+    'experimental',
+    'planner_hint',
+    'manual_refresh',
+    'stub',
+    'degraded',
+    'planned'
+);
+
+-- arrow_flight must not claim to be implemented (it is a stub).
+SELECT status AS arrow_flight_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'arrow_flight';
+
+-- wcoj must be planner_hint (not a full triejoin executor).
+SELECT status AS wcoj_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'wcoj';
+
+-- shacl_sparql_rule must not be implemented yet.
+SELECT status NOT IN ('implemented') AS shacl_rule_not_implemented
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'shacl_sparql_rule';
+
+-- construct_writeback must be manual_refresh (not implemented).
+SELECT status AS construct_writeback_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'construct_writeback';
+
+-- citus_service_pruning must be planned (not wired into translator yet).
+SELECT status NOT IN ('implemented') AS citus_pruning_not_implemented
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'citus_service_pruning';
+
+-- sparql_select and sparql_update must be implemented.
+SELECT feature_name, status
+FROM pg_ripple.feature_status()
+WHERE feature_name IN ('sparql_select', 'sparql_update')
+ORDER BY feature_name;
+
+-- shacl_sparql_constraint must be implemented (distinct from shacl_sparql_rule).
+SELECT status AS shacl_constraint_status
+FROM pg_ripple.feature_status()
+WHERE feature_name = 'shacl_sparql_constraint';
+
+-- Every row must have a non-null feature_name and status.
+SELECT count(*) AS null_feature_names
+FROM pg_ripple.feature_status()
+WHERE feature_name IS NULL OR status IS NULL;

--- a/tests/pg_regress/sql/shacl_sparql_constraint.sql
+++ b/tests/pg_regress/sql/shacl_sparql_constraint.sql
@@ -49,8 +49,8 @@ SELECT pg_ripple.insert_triple(
 SELECT count(*) >= 0 AS validate_ok
 FROM pg_ripple.validate();
 
--- ── 5. schema_version contains 0.63.0 ────────────────────────────────────────
-SELECT version = '0.63.0' AS version_correct
+-- ── 5. schema_version contains 0.64.0 ────────────────────────────────────────
+SELECT version = '0.64.0' AS version_correct
 FROM _pg_ripple.schema_version
 ORDER BY installed_at DESC
 LIMIT 1;


### PR DESCRIPTION
## Summary

v0.64.0 — Release Truth and Safety Freeze: a non-feature release that makes the shipped capabilities honest and safe. All 10 TRUTH deliverables are implemented, ensuring operators can trust what `pg_ripple` claims to do before relying on it in production.

## Changes

### TRUTH-01 — Feature Status Catalog
- New `pg_ripple.feature_status()` SQL function returns one row per major capability with an honest status value: `implemented`, `experimental`, `planner_hint`, `manual_refresh`, `stub`, `degraded`, or `planned`
- Covers 19 features: SPARQL SELECT/UPDATE/CONSTRUCT, property paths, federation, cursor streaming, CONSTRUCT writeback, SHACL, Datalog/OWL-RL, HTAP storage, Citus scalability, Arrow Flight, WCOJ, vector search, GraphRAG, CDC subscriptions
- Adds pg_regress test: `tests/pg_regress/sql/feature_status.sql`

### TRUTH-02 — Deep /ready Endpoint
- `pg_ripple_http` `/ready` handler now queries `pg_ripple.feature_status()` and returns `partial_features` and `degraded_features` in the JSON response
- Returns HTTP 200 when operational, HTTP 503 with detail when PostgreSQL is unreachable

### TRUTH-03 — GitHub Actions SHA Pinning
- All 6 workflow files (`ci.yml`, `release.yml`, `docs.yml`, `docs-test.yml`, `benchmark.yml`, `cargo-audit.yml`) updated to pin every `uses:` reference to an immutable SHA
- New `scripts/check_github_actions_pinned.sh` lint script fails CI if any mutable ref is introduced
- CI step added to run the lint on every push

### TRUTH-04 — Docker Release Digest Integrity
- Removed `continue-on-error: true` from the Docker build/push step in `release.yml`
- Added digest capture step; build fails if Docker Hub does not return a digest
- Trivy scan now references `ghcr.io/grove/pg-ripple@${{ steps.digest.outputs.digest }}` (immutable) instead of a mutable tag

### TRUTH-05 — Documentation Truth Pass
- `README.md`: updated "What works today" from v0.59.0 to v0.63.0; added "Known limitations in v0.63.0" table
- `plans/implementation_plan.md`: updated all 4 `pgrx 0.17` references to `pgrx 0.18`
- `docs/src/reference/faq.md`: updated pgrx version reference

### TRUTH-06 — Roadmap Evidence Check
- New `scripts/check_roadmap_evidence.sh` advisory lint for CHANGELOG completion claims without evidence markers

### TRUTH-07 — API Drift Check
- New `scripts/check_api_drift.sh` checks that every `#[pg_extern]` function name appears in the documentation tree

### TRUTH-08 — `just assess-release`
- New `assess-release` target in `justfile` runs the full pre-release quality checklist

### TRUTH-09 — Release Evidence Dashboard
- New `scripts/generate_release_evidence.sh` generates `target/release-evidence/<version>/summary.json` and `summary.md`
- CI step in `release.yml` generates and uploads the evidence bundle as a workflow artifact

### TRUTH-10 — Degradation Semantics Guide
- New `docs/src/reference/degradation.md` documents degradation behaviour for all optional-dependency features (pgvector, pg_trickle, Citus, etc.)
- Added to `docs/src/SUMMARY.md`

### Other
- `Cargo.toml` and `pg_ripple.control`: version bumped to `0.64.0`
- `CHANGELOG.md`: v0.64.0 entry added
- `ROADMAP.md`: v0.64.0 status updated to In Progress
- `sql/pg_ripple--0.63.0--0.64.0.sql`: migration script (no DDL changes; documents new functions and scripts)

## Testing

- `cargo fmt --all` — clean
- `cargo clippy --features pg18 -- -D warnings` — zero warnings
- `cargo check --features pg18` — clean
- Regress test `tests/pg_regress/sql/feature_status.sql` added with expected output
- macOS local `cargo pgrx test pg18` fails with pre-existing `_CacheMemoryContext` dyld flat-namespace error (Linux CI unaffected)

## Notes

This is a correctness/honesty release with no breaking API changes. The new `feature_status()` function is purely additive. All existing behaviour is unchanged.
