### PR TITLE
docs: improve JSON round-tripping via declarative JSON-LD framing

### DIFF
--- a/docs/src/operations/pg-trickle-relay.md
+++ b/docs/src/operations/pg-trickle-relay.md
@@ -233,9 +233,17 @@ devices across sources that share a serial number (entity resolution):
 SELECT pg_ripple.load_rules(
     rules    => $$
         % Derive an alert for any observation above the threshold.
-        % The inferred triple is: <obs> ex:tempAlert <device>
+        % Two triples are inferred per matching observation:
+        %   <obs> ex:tempAlert <device>          — links observation to device
+        %   <obs> ex:alertType "high_temperature" — records the alert category
+        % Storing the alert type as a literal triple keeps the meaning inside
+        % the triplestore rather than hardcoding it in downstream trigger code.
         ex:tempAlert(Obs, Device) :-
             saref:measurementMadeBy(Obs, Device),
+            saref:hasValue(Obs, Val),
+            Val > 40.0.
+
+        ex:alertType(Obs, "high_temperature") :-
             saref:hasValue(Obs, Val),
             Val > 40.0.
 
@@ -250,13 +258,17 @@ SELECT pg_ripple.load_rules(
 );
 ```
 
-When a 45°C reading arrives from `sensor-7`, these rules materialise a new
-triple — an inferred fact that did not exist in the raw data:
+When a 45°C reading arrives from `sensor-7`, these rules materialise two new
+triples — inferred facts that did not exist in the raw data:
 
 ```
 <https://example.org/observation/kafka:iot.sensors:0:99>
     <https://example.org/tempAlert>
     <https://example.org/device/sensor-7> .
+
+<https://example.org/observation/kafka:iot.sensors:0:99>
+    <https://example.org/alertType>
+    "high_temperature" .
 ```
 
 ### Step 4 — Enforce data quality with SHACL
@@ -324,29 +336,44 @@ SELECT pg_ripple.enable_cdc_bridge_trigger(
 );
 
 -- Reformat the raw decoded triple into plain JSON before the row is committed.
--- enable_cdc_bridge_trigger writes {subject, predicate, object, graph} with
--- full IRI strings. This BEFORE INSERT trigger rewrites the payload back to
--- the same field names the sensor originally sent, with the inferred "alert"
--- field added. The subject IRI encodes the original event_id, so we can join
--- straight back to sensor_inbox to recover the source values.
+-- The frame template is a static JSONB literal: the @context maps short
+-- property names to the stored SAREF predicate IRIs, and the property slots
+-- ({}) tell pg_ripple which predicates to pull. Only the @id is dynamic —
+-- it scopes the generated CONSTRUCT query to this specific observation.
+-- The final unwrap + strip step removes JSON-LD structural keywords so the
+-- consumer receives the same plain JSON as before, but the output shape is
+-- now fully described by the frame rather than hand-assembled field by field.
 CREATE OR REPLACE FUNCTION reformat_alert_payload()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
 DECLARE
-    src RECORD;
+    framed JSONB;
+    item   JSONB;
 BEGIN
-    SELECT payload INTO src
-    FROM sensor_inbox
-    WHERE event_id = split_part(NEW.payload ->> 'subject', '/observation/', 2)
-    LIMIT 1;
+    framed := pg_ripple.export_jsonld_framed(
+        frame => '{
+            "@context": {
+                "device": "https://saref.etsi.org/core/measurementMadeBy",
+                "temp":   "https://saref.etsi.org/core/hasValue",
+                "unit":   "https://qudt.org/schema/qudt/unit",
+                "ts":     "https://saref.etsi.org/core/hasTimestamp",
+                "alert":  "https://example.org/alertType"
+            },
+            "@type":  "https://saref.etsi.org/core/Measurement",
+            "device": {},
+            "temp":   {},
+            "unit":   {},
+            "ts":     {},
+            "alert":  {}
+        }'::jsonb || jsonb_build_object('@id', NEW.payload ->> 'subject')
+    );
 
-    IF FOUND THEN
-        NEW.payload := jsonb_build_object(
-            'device', src.payload ->> 'device',
-            'temp',   (src.payload ->> 'temp')::numeric,
-            'unit',   src.payload ->> 'unit',
-            'ts',     src.payload ->> 'ts',
-            'alert',  'high_temperature'
-        );
+    -- @context lives at the top level of the framed document and is discarded
+    -- automatically when we unwrap @graph. @type and @id sit on the node
+    -- itself; strip them with the jsonb - operator to get plain JSON.
+    item := (framed -> '@graph' -> 0) - '@type' - '@id';
+
+    IF item IS NOT NULL THEN
+        NEW.payload := item;
     END IF;
 
     RETURN NEW;
@@ -398,11 +425,18 @@ SELECT pgtrickle.set_relay_outbox(
 );
 ```
 
-The `reformat_alert_payload` trigger rewrites the decoded triple back to the
-same field names the sensor originally sent (`device`, `temp`, `unit`, `ts`),
-with the inferred `alert` field added. A consumer reading from `iot.alerts` sees
-a plain JSON document it can process without any knowledge of RDF or the
-triplestore:
+The `reformat_alert_payload` trigger produces the same plain JSON as the
+previous `jsonb_build_object` version, but the entire output shape is now
+described by the static frame template — including the `alert` field. The
+`ex:alertType` literal triple was inferred by the Datalog rule in Step 3, so
+the frame simply maps the short name `"alert"` to that predicate and picks it
+up like any other property; there is nothing to hardcode in the trigger. The
+`||` appends only the dynamic `@id` to scope the generated CONSTRUCT query to
+this specific observation. Two steps then strip the JSON-LD structural
+keywords: `-> '@graph' -> 0` unwraps the node and discards the top-level
+`@context`; `- '@type' - '@id'` removes the remaining keywords from the node.
+A consumer reading from `iot.alerts` sees a plain JSON document it can process
+without any knowledge of RDF or the triplestore:
 
 ```json
 {
@@ -463,11 +497,13 @@ this pattern automatically — you do not need to write the trigger function by
 hand. The raw `{subject, predicate, object, graph}` payload is useful on its
 own, but you can also reshape it before it leaves the outbox:
 
-- **Plain JSON** — add a `BEFORE INSERT` trigger that rewrites the payload to
-  match the original source field names, as Step 5 does with
-  `reformat_alert_payload()`.
-- **JSON-LD** — replace the default function with one that calls
-  `export_jsonld_framed()` (see
+- **Plain JSON via framing** — add a `BEFORE INSERT` trigger that calls
+  `export_jsonld_framed()` with the desired `@context`, unwraps `@graph`, and
+  strips `@type` and `@id` with the jsonb `-` operator, as Step 5 does with
+  `reformat_alert_payload()`. This is more declarative than building the payload
+  manually with `jsonb_build_object` — changing an outbound property name is a
+  one-line `@context` edit rather than a code change.
+- **Full JSON-LD** — store the framed document directly without stripping (see
   [Outbound framing](#json-ld-mapping-inbound-context-and-outbound-framing)).
 
 **Best for**: High-priority alerts, strict transactional guarantees.  
@@ -767,6 +803,21 @@ The downstream consumer receives a document shaped exactly to the frame — with
 short, readable property names from the `@context`, nested objects where the
 frame requests them, and a self-describing `@context` block so it can be parsed
 without any knowledge of pg_ripple's internals.
+
+If the downstream consumer expects plain JSON rather than JSON-LD, strip the
+structural keywords before inserting into the outbox:
+
+```sql
+-- @context is at the top level; -> '@graph' -> 0 discards it automatically.
+-- @type and @id live on the node; chain - to remove them in one expression.
+item := (framed -> '@graph' -> 0) - '@type' - '@id';
+
+INSERT INTO enriched_events (event_type, payload)
+VALUES ('alert', item);
+```
+
+The jsonb `-` operator accepts either a single key (`- '@type'`) or a text
+array (`- ARRAY['@type','@id']`) to remove several keywords at once.
 
 ### Debugging the frame translation
 

--- a/roadmap/v0.72.0-full.md
+++ b/roadmap/v0.72.0-full.md
@@ -16,6 +16,8 @@
 | OBS-02 | Expose extension `streaming_metrics()` via a `/metrics/extension` route in `pg_ripple_http` | Required |
 | GUC-DOC-01 | `docs/src/reference/guc-reference.md`: cross-reference `arrow_batch_size`, `export_batch_size`, `vp_promotion_batch_size` | Required |
 | CITUS-URL-01 | Add unit tests for `is_citus_worker_endpoint()` / `extract_url_host()` edge cases | Required |
+| JSONLD-NODE-01 | Add `pg_ripple.export_jsonld_node(frame, subject_id, strip)` to eliminate CDC bridge trigger boilerplate | Required |
+| BUG-JSONLD-LIST-01 | Fix `@container: @list` support in inbound context parser and outbound framing embedder | Required |
 
 ---
 
@@ -185,6 +187,159 @@ Add `tests/pg_regress/sql/citus_url_parsing.sql` with inputs:
 - `not-a-url` (malformed — should return false, not panic)
 - `http://worker1.internal/db` (normal case)
 
+### JSONLD-NODE-01 — `export_jsonld_node()` convenience function
+
+**Root cause**: UX-01. CDC bridge triggers that use `export_jsonld_framed()` to produce plain JSON currently require three repeated steps at every call site:
+1. Append `@id` to the static frame: `frame || jsonb_build_object('@id', decode_id(NEW.s))`
+2. Unwrap the node: `framed -> '@graph' -> 0`
+3. Strip JSON-LD keywords: `- '@type' - '@id'`
+
+This boilerplate is error-prone and obscures intent. The three steps are always performed together; the engine already has all the information needed to do them internally.
+
+**Signature**:
+
+```sql
+CREATE OR REPLACE FUNCTION pg_ripple.export_jsonld_node(
+    frame      JSONB,
+    subject_id BIGINT,
+    strip      TEXT[]  DEFAULT ARRAY['@type', '@id']
+) RETURNS JSONB
+```
+
+**Semantics**:
+
+1. Look up the IRI for `subject_id` in `_pg_ripple.dictionary`. Raise an error if not found.
+2. Append `{"@id": "<iri>"}` to `frame` and call `export_jsonld_framed(frame => ...)` internally.
+3. Extract `result -> '@graph' -> 0`. If `NULL` (no matching triples), return `NULL`.
+4. Remove each key in `strip` from the node using the JSONB `-` operator.
+5. Return the resulting JSONB object.
+
+**Parameters**:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `frame` | `JSONB` | — | Static frame template. Must contain `@context` and at least one property slot (`{}`). Must **not** contain `@id`; `subject_id` provides it. |
+| `subject_id` | `BIGINT` | — | Dictionary ID of the subject node. In a VP table trigger, pass `NEW.s` directly. |
+| `strip` | `TEXT[]` | `ARRAY['@type','@id']` | JSON-LD keyword keys to remove from the output node. Pass `ARRAY[]::TEXT[]` to keep all keywords (returns a full JSON-LD node object). |
+
+**Typical trigger usage**:
+
+```sql
+CREATE OR REPLACE FUNCTION bridge_alert_to_outbox()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO enriched_events (event_type, payload)
+    VALUES (
+        'alert',
+        pg_ripple.export_jsonld_node(
+            frame => '{
+                "@context": {
+                    "device": "https://saref.etsi.org/core/measurementMadeBy",
+                    "temp":   "https://saref.etsi.org/core/hasValue",
+                    "unit":   "https://qudt.org/schema/qudt/unit",
+                    "ts":     "https://saref.etsi.org/core/hasTimestamp",
+                    "alert":  "https://example.org/alertType"
+                },
+                "@type":  "https://saref.etsi.org/core/Measurement",
+                "device": {}, "temp": {}, "unit": {}, "ts": {}, "alert": {}
+            }'::jsonb,
+            subject_id => NEW.s
+        )
+    );
+    RETURN NEW;
+END;
+$$;
+```
+
+**Recursive strip**:
+
+The `strip` parameter must be applied recursively, not just to the root node.
+Embedded blank nodes from nested objects also carry `@id` (e.g. `"@id": "_:b0"`),
+and consumers expecting plain JSON do not want those either. The implementation
+must walk the entire output tree and remove listed keys from every object node.
+
+```
+-- Example: calibration sub-objects without recursive strip
+{ "calibration": [ { "@id": "_:b0", "date": "2026-01-15" } ] }
+
+-- With recursive strip (default behaviour)
+{ "calibration": [ { "date": "2026-01-15" } ] }
+```
+
+Pass `strip => ARRAY[]::TEXT[]` to suppress recursive stripping entirely and
+receive a full JSON-LD node graph, including embedded `@id`s — useful when
+the consumer is itself a JSON-LD processor.
+
+**`@container: @list` support (known gap — confirmed bug)**:
+
+Arrays round-trip correctly only for *unordered* sets (e.g. tags). For ordered
+arrays, JSON-LD 1.1 requires `@container: @list` in both the inbound context
+and the outbound frame. This is **not currently implemented**; the gap exists
+in two places:
+
+1. **Inbound** (`src/bulk_load.rs`, `json_to_ntriples` context parser): context
+   entries with object values — e.g. `{"@id": "ex:steps", "@container": "@list"}`
+   — are silently dropped because the parser only matches `serde_json::Value::String`.
+   The predicate IRI is never registered, and the array is stored as unordered
+   parallel triples rather than an `rdf:List` cons-cell chain.
+
+2. **Outbound** (`src/framing/embedder.rs`, `build_node_map`): object values are
+   collected into `Vec<Value>` with no ordering guarantee. `@container: @list`
+   in the frame is not read; `rdf:first` / `rdf:rest` traversal is absent.
+
+This bug is fixed in v0.72.0 as **BUG-JSONLD-LIST-01** (see below).
+
+**Implementation location**: `src/export/jsonld_node.rs` (new file). The existing `export_jsonld_framed` Rust implementation is called internally; no SPARQL translation logic is duplicated.
+
+**Doc update**: Update `docs/src/operations/pg-trickle-relay.md` Step 5 trigger to use `export_jsonld_node()` once the function is implemented, replacing the current `export_jsonld_framed() || jsonb_build_object('@id', ...)` + unwrap + strip pattern.
+
+**Tests**: Add to `tests/pg_regress/sql/export_jsonld_node.sql`:
+- Returns correct plain JSON with default `strip`.
+- Returns full JSON-LD node with `strip => ARRAY[]::TEXT[]`.
+- Returns `NULL` when no triples match the subject.
+- Errors with a descriptive message when `subject_id` is not in the dictionary.
+- Frame that already contains `@id` raises an error (guard against accidental override).
+- Nested object (blank node sub-object) has `@id` stripped recursively by default.
+- Nested object retains `@id` when `strip => ARRAY[]::TEXT[]`.
+
+---
+
+### BUG-JSONLD-LIST-01 — `@container: @list` round-trip fidelity
+
+**Root cause**: Two independent gaps prevent ordered arrays from round-tripping correctly through the ingest → triplestore → frame pipeline.
+
+**Fix 1 — Inbound context parser** (`src/bulk_load.rs`, `json_to_ntriples`):
+
+The context loop matches only `serde_json::Value::String` values. An entry like
+`"steps": {"@id": "ex:steps", "@container": "@list"}` is an object, so it is
+silently discarded and the predicate is never registered.
+
+1. Extend the context loop to also match `serde_json::Value::Object`: extract the
+   `@id` string as the predicate IRI and record `@container` in a separate
+   `HashMap<String, String>` (key → container type).
+2. In `json_object_to_ntriples_inner`, when the array branch fires and the
+   predicate's container type is `"@list"`, emit an `rdf:List` cons-cell chain
+   (`rdf:first` / `rdf:rest`) instead of parallel triples. Terminate with
+   `rdf:nil`.
+
+**Fix 2 — Outbound framing embedder** (`src/framing/embedder.rs`, `build_node_map` and frame matching):
+
+1. When resolving a frame property slot, check if the compacted frame context
+   declares `@container: @list` for that property.
+2. If so, instead of collecting object values directly, traverse the stored
+   `rdf:first` / `rdf:rest` chain rooted at the blank node value and collect
+   objects in chain order.
+3. Emit the collected values as a JSON array in the output node.
+
+**Tests**: Add to `tests/pg_regress/sql/jsonld_list_roundtrip.sql`:
+- Ingest a JSON array of strings with `@container: @list`; verify stored triples
+  form an `rdf:List` chain (query `rdf:first` / `rdf:rest` directly).
+- Frame the result with `@container: @list`; verify output array order matches input.
+- Ingest a JSON array of objects with `@container: @list`; verify nested blank
+  nodes are chained and round-trip in order.
+- Ingest an array *without* `@container: @list`; verify it is stored as parallel
+  triples (existing behaviour unchanged).
+
 ---
 
 ## Exit criteria
@@ -201,4 +356,6 @@ Add `tests/pg_regress/sql/citus_url_parsing.sql` with inputs:
 - [ ] OBS-02: `/metrics/extension` route returns `streaming_metrics()` JSON.
 - [ ] GUC-DOC-01: GUC reference doc created.
 - [ ] CITUS-URL-01: URL parsing edge-case tests pass.
+- [ ] JSONLD-NODE-01: `export_jsonld_node()` function exists; recursive strip works on nested blank nodes; pg_regress tests pass; `docs/src/operations/pg-trickle-relay.md` Step 5 updated to use the new function.
+- [ ] BUG-JSONLD-LIST-01: `@container: @list` ingest emits `rdf:List` chain; framing embedder traverses chain in order; round-trip order test passes.
 - [ ] All 190+ pg_regress tests pass.

--- a/roadmap/v0.72.0-full.md
+++ b/roadmap/v0.72.0-full.md
@@ -18,6 +18,10 @@
 | CITUS-URL-01 | Add unit tests for `is_citus_worker_endpoint()` / `extract_url_host()` edge cases | Required |
 | JSONLD-NODE-01 | Add `pg_ripple.export_jsonld_node(frame, subject_id, strip)` to eliminate CDC bridge trigger boilerplate | Required |
 | BUG-JSONLD-CONTEXT-01 | Fix object-form context entries: `@container: @list`, `@type` (datatype), `@type: @id` (IRI ref), `@language` | Required |
+| RT-FIX-04B | Reject (not silently lose) JSON integers that exceed `i64` range; preserve as `xsd:integer` string | Required |
+| RT-FIX-06 | Distinguish JSON float `5.0` from integer `5` at ingest; store the former as `xsd:decimal` | Required |
+| RT-FIX-07 | Validate IRI local parts under `@vocab` expansion; reject keys containing spaces, slashes, or other reserved characters | Required |
+| RT-TEST-02 | Regression test confirming empty objects round-trip correctly via blank node + recursive strip | Required |
 
 ---
 
@@ -89,7 +93,8 @@ v0.72.0 is an architecture depth and protocol hardening release. The headlining 
 1. Add `src/sparql/proptest_construct.rs` (or `tests/proptest/construct_template.rs`).
 2. Generator: random binding sets for a fixed CONSTRUCT template.
 3. Property: `apply_construct_template(template, bindings)` produces the same set of quads as evaluating the CONSTRUCT naively over the same bindings.
-4. Run via `cargo test --features pg18 -- proptest`.
+4. **JSON round-trip generator (RT-10)**: add a second proptest target that generates random heterogeneous JSON payloads (mixed primitive types in arrays, nested objects, optional null fields) and asserts `json_to_ntriples_and_load()` followed by `export_jsonld_framed()` returns the same value modulo the documented impedance mismatches (RT-05, RT-08, RT-09).
+5. Run via `cargo test --features pg18 -- proptest`.
 
 ### FUZZ-02 — SPARQL Update fuzz target
 
@@ -371,31 +376,113 @@ Without these, ordered lists are flattened, datetimes become strings, IRIs becom
 - [ ] CITUS-URL-01: URL parsing edge-case tests pass.
 - [ ] JSONLD-NODE-01: `export_jsonld_node()` function exists; recursive strip works on nested blank nodes; pg_regress tests pass; `docs/src/operations/pg-trickle-relay.md` Step 5 updated to use the new function.
 - [ ] BUG-JSONLD-CONTEXT-01: object-form context entries handled for `@container: @list`, `@type`, `@type: @id`, and `@language`; round-trip tests pass for all four.
+- [ ] RT-FIX-04B: i64 overflow at ingest raises a descriptive error or stores via string preservation path; regression test passes.
+- [ ] RT-FIX-06: float `5.0` stored as `xsd:decimal`, integer `5` stored as `xsd:integer`; regression test passes.
+- [ ] RT-FIX-07: invalid IRI components under `@vocab` raise a descriptive error suggesting an explicit context entry; regression test passes.
+- [ ] RT-TEST-02: empty object round-trip regression test passes.
 - [ ] All 190+ pg_regress tests pass.
 
 ---
 
-## JSON round-trip: known deferred corner cases
+## JSON round-trip: corner case dispositions
 
-With JSONLD-NODE-01 and BUG-JSONLD-CONTEXT-01 landed, the JSON → RDF → JSON
-round-trip handles the bulk of real-world payloads. The following corner cases
-are **deliberately deferred** to a later release; each is independent and does
-not block the relay or HTAP use cases.
+With JSONLD-NODE-01, BUG-JSONLD-CONTEXT-01, and the small targeted fixes
+(RT-FIX-04B / RT-FIX-06 / RT-FIX-07 / RT-TEST-02) landed, the JSON → RDF → JSON
+round-trip handles the bulk of real-world payloads. Each known corner case is
+dispositioned below. "Fix" means a code change in v0.72.0; "Document" means an
+entry in `docs/src/reference/json-roundtrip.md`; "Defer" means a tracked ticket
+for v0.73.0 or later.
 
-| ID | Case | Current behaviour | Workaround |
+| ID | Case | Disposition | Detail |
 |---|---|---|---|
-| RT-01 | Empty array `[]` | Predicate not stored; output key absent | Caller adds `IS NULL → []` post-step |
-| RT-02 | Empty object `{}` | Stored as bare blank node; round-trips to `{}` after recursive strip | None needed for typical use |
-| RT-03 | Multi-graph ingest (`{"@graph": [...]}`) | `json_to_ntriples_and_load()` accepts only a single subject; caller must loop | Loop in pl/pgSQL; outbound `@graph` already supported |
-| RT-04 | Numeric precision (>2^53) | Stored as `xsd:integer`; lossy in JS clients | Caller stringifies; future: `@type: xsd:long` hint |
-| RT-05 | Decimal trailing zeros (`22.50`) | Normalised to `22.5` | Documented; RDF semantic |
-| RT-06 | Float vs integer (`5.0` vs `5`) | serde collapses; first writer wins | Use explicit `@type` in context |
-| RT-07 | Property names with spaces or slashes | Concatenated into malformed IRI under `@vocab` | Validate at ingest (separate ticket) |
-| RT-08 | `null` vs absent | Both produce no triple; indistinguishable on output | RDF has no null |
-| RT-09 | Duplicate keys in source JSON | Last-write-wins (serde) | JSON parser limitation, not RDF |
-| RT-10 | Heterogeneous arrays of mixed types | Works but no test coverage | Add proptest in v0.73.0 |
+| RT-01 | Empty array `[]` | **Fixed by BUG-JSONLD-CONTEXT-01** for `@container: @list` predicates (`[]` becomes `<s> p rdf:nil`); document workaround for unordered predicates |
+| RT-02 | Empty object `{}` | **Test in v0.72.0** (RT-TEST-02) | Already works correctly via blank node + recursive strip; add regression test only |
+| RT-03 | Multi-graph ingest (`{"@graph": [...]}`) | **Defer to v0.73.0 as JSONLD-INGEST-02** | Use `oxjsonld` (already in tree via `oxrdf`) to parse full JSON-LD documents in one call instead of requiring caller to loop |
+| RT-04a | Numeric precision (>2^53) at the consumer (JS) | **Document** | Inherent to JavaScript number representation; consumers should add `@type: xsd:long` to context to receive strings on the way out |
+| RT-04b | i64 overflow at ingest (`>9.2e18`) | **Fix in v0.72.0** (RT-FIX-04B) | Currently falls through to `as_f64()` and silently loses precision; should raise an error or use a string-preservation path |
+| RT-05 | Decimal trailing zeros (`22.50`) | **Document** | Lost at JSON parse time before pg_ripple sees the value; not fixable |
+| RT-06 | Float `5.0` collapses to integer `5` | **Fix in v0.72.0** (RT-FIX-06) | `bulk_load.rs` checks `as_i64()` before `is_f64()`; reverse the check to preserve the source datatype |
+| RT-07 | Property names with spaces or slashes | **Fix in v0.72.0** (RT-FIX-07) | Currently produces malformed IRIs under `@vocab`; validate and raise a descriptive error pointing at the explicit-context-entry workaround |
+| RT-08 | `null` vs absent field | **Document** | RDF has no null; reifying it (e.g. as `rdf:nil` object) breaks aggregations; recommend a sentinel string at the source |
+| RT-09 | Duplicate keys in source JSON | **Document** | JSON spec leaves behaviour undefined; serde keeps the last value; pre-RDF concern |
+| RT-10 | Heterogeneous arrays of mixed types | **Test in v0.72.0** (rolled into PROPTEST-01) | Already works; needs a property-test generator to confirm coverage |
 
-Items RT-01, RT-03, RT-07 are tracked as separate backlog tickets and slated
-for v0.73.0 consideration. The remaining items are inherent JSON ↔ RDF
-impedance mismatches and will be documented in `docs/src/reference/json-roundtrip.md`
-rather than fixed.
+### Detail: RT-FIX-04B — i64 overflow at ingest
+
+**Root cause**: In `src/bulk_load.rs` `json_value_to_nt_term`, when a JSON
+`Number` exceeds `i64::MAX`, `n.as_i64()` returns `None` and the code falls
+through to `n.as_f64()`, silently losing precision for any integer above 2^53.
+
+**Fix**: Try `as_i64()` first, then `as_u64()` (covers values up to 2^64−1),
+then check if the textual representation contains no decimal point. If the
+number is a non-fractional integer that exceeds `u64::MAX`, preserve the
+source string (`n.to_string()`) and emit it as `"<digits>"^^xsd:integer` —
+`xsd:integer` is unbounded in the value space. Only fall through to `as_f64()`
+for genuine floating-point values.
+
+**Test**: ingest `{"id": 18446744073709551616}` (one past `u64::MAX`); verify
+stored triple is `xsd:integer "18446744073709551616"`; verify framing returns
+the same value as a string (with appropriate `@type` hint in context).
+
+### Detail: RT-FIX-06 — float vs integer at ingest
+
+**Root cause**: In `src/bulk_load.rs` `json_value_to_nt_term`, the match arm
+for `serde_json::Value::Number` calls `n.as_i64()` first. JSON `5.0` parses
+to a `Number` whose internal representation knows it was a float (via
+`is_f64()`), but `as_i64()` succeeds on it and returns `5`, so we emit
+`"5"^^xsd:integer` and lose the source datatype.
+
+**Fix** (five-line patch):
+
+```rust
+serde_json::Value::Number(n) => {
+    if n.is_f64() {
+        n.as_f64().map(|f| format!("\"{}\"^^<http://www.w3.org/2001/XMLSchema#decimal>", f))
+    } else if let Some(i) = n.as_i64() {
+        Some(format!("\"{}\"^^<http://www.w3.org/2001/XMLSchema#integer>", i))
+    } else {
+        // u64 in (i64::MAX, u64::MAX] — fall through to RT-FIX-04B path
+        n.as_u64().map(|u| format!("\"{}\"^^<http://www.w3.org/2001/XMLSchema#integer>", u))
+    }
+}
+```
+
+**Test**: ingest `{"a": 5, "b": 5.0}`; verify triple for `a` has `xsd:integer`
+and triple for `b` has `xsd:decimal`.
+
+### Detail: RT-FIX-07 — IRI local-part validation
+
+**Root cause**: In `src/bulk_load.rs` `json_to_ntriples`, when `@vocab` is
+set, the parser concatenates `vocab + key` to form the predicate IRI. A key
+like `"field with space"` produces `https://example.org/field with space`,
+which is not a valid IRI — spaces, control characters, `<`, `>`, `"`, and `{}`
+are forbidden in IRI references (RFC 3987).
+
+**Fix**: Before concatenation, validate the key against the IRI ipchar grammar.
+If invalid, raise a descriptive error:
+
+```
+ERROR: cannot derive predicate IRI from JSON key "field with space"
+DETAIL: keys expanded under @vocab must contain only valid IRI characters
+HINT: add an explicit context entry, e.g. "field with space": "ex:fieldWithSpace"
+```
+
+Validation rejects: any character in `\x00-\x20`, ` `, `"`, `<`, `>`, `\\`, `^`,
+`` ` ``, `{`, `|`, `}`, plus the unicode ranges excluded by RFC 3987 ipchar.
+
+**Test**: ingest payloads with malformed keys; verify each raises the expected
+error with the suggested workaround. Verify keys with valid Unicode
+(e.g. `"föräldrar"`) succeed.
+
+### Detail: RT-TEST-02 — empty object regression test
+
+**Root cause**: RT-02 was initially flagged as a corner case but works
+correctly today: `{ "address": {} }` is stored as `<subj> ex:address _:b0`
+with no further triples on `_:b0`; round-trips through framing as
+`{ "address": { "@id": "_:b0" } }`; recursive strip in `export_jsonld_node()`
+produces `{ "address": {} }`.
+
+**Test**: add to `tests/pg_regress/sql/jsonld_empty_object_roundtrip.sql`.
+Ingest a payload with an empty-object property; export via
+`export_jsonld_node()`; assert output equals the original payload (modulo
+`@id` / `@type`).

--- a/roadmap/v0.72.0-full.md
+++ b/roadmap/v0.72.0-full.md
@@ -17,7 +17,7 @@
 | GUC-DOC-01 | `docs/src/reference/guc-reference.md`: cross-reference `arrow_batch_size`, `export_batch_size`, `vp_promotion_batch_size` | Required |
 | CITUS-URL-01 | Add unit tests for `is_citus_worker_endpoint()` / `extract_url_host()` edge cases | Required |
 | JSONLD-NODE-01 | Add `pg_ripple.export_jsonld_node(frame, subject_id, strip)` to eliminate CDC bridge trigger boilerplate | Required |
-| BUG-JSONLD-LIST-01 | Fix `@container: @list` support in inbound context parser and outbound framing embedder | Required |
+| BUG-JSONLD-CONTEXT-01 | Fix object-form context entries: `@container: @list`, `@type` (datatype), `@type: @id` (IRI ref), `@language` | Required |
 
 ---
 
@@ -274,20 +274,9 @@ the consumer is itself a JSON-LD processor.
 
 Arrays round-trip correctly only for *unordered* sets (e.g. tags). For ordered
 arrays, JSON-LD 1.1 requires `@container: @list` in both the inbound context
-and the outbound frame. This is **not currently implemented**; the gap exists
-in two places:
-
-1. **Inbound** (`src/bulk_load.rs`, `json_to_ntriples` context parser): context
-   entries with object values — e.g. `{"@id": "ex:steps", "@container": "@list"}`
-   — are silently dropped because the parser only matches `serde_json::Value::String`.
-   The predicate IRI is never registered, and the array is stored as unordered
-   parallel triples rather than an `rdf:List` cons-cell chain.
-
-2. **Outbound** (`src/framing/embedder.rs`, `build_node_map`): object values are
-   collected into `Vec<Value>` with no ordering guarantee. `@container: @list`
-   in the frame is not read; `rdf:first` / `rdf:rest` traversal is absent.
-
-This bug is fixed in v0.72.0 as **BUG-JSONLD-LIST-01** (see below).
+and the outbound frame. This is part of a broader bug — the inbound context
+parser silently drops every object-form entry, not just `@container` — fixed
+in v0.72.0 as **BUG-JSONLD-CONTEXT-01** (see below).
 
 **Implementation location**: `src/export/jsonld_node.rs` (new file). The existing `export_jsonld_framed` Rust implementation is called internally; no SPARQL translation logic is duplicated.
 
@@ -304,41 +293,65 @@ This bug is fixed in v0.72.0 as **BUG-JSONLD-LIST-01** (see below).
 
 ---
 
-### BUG-JSONLD-LIST-01 — `@container: @list` round-trip fidelity
+### BUG-JSONLD-CONTEXT-01 — Object-form context entries
 
-**Root cause**: Two independent gaps prevent ordered arrays from round-tripping correctly through the ingest → triplestore → frame pipeline.
+**Root cause**: The inbound context parser (`src/bulk_load.rs`, `json_to_ntriples`) matches only `serde_json::Value::String` values. Any context entry whose value is a JSON object — e.g. `{"@id": "ex:ts", "@type": "xsd:dateTime"}` — is silently discarded and the predicate is never registered. This single defect blocks four distinct JSON-LD features that all use object-form entries:
+
+| Feature | Context entry shape | What it enables |
+|---|---|---|
+| `@container: @list` | `{"@id": "ex:steps", "@container": "@list"}` | Ordered arrays via `rdf:List` cons-cell chains |
+| Datatype hints | `{"@id": "ex:ts", "@type": "xsd:dateTime"}` | Round-trip typed literals (datetime, base64, etc.) |
+| IRI references | `{"@id": "ex:homepage", "@type": "@id"}` | Round-trip URI-valued fields as IRIs, not strings |
+| Language tags | `{"@id": "schema:name", "@language": "en"}` | Round-trip language-tagged strings |
+
+Without these, ordered lists are flattened, datetimes become strings, IRIs become strings, and language information is lost on ingest.
 
 **Fix 1 — Inbound context parser** (`src/bulk_load.rs`, `json_to_ntriples`):
 
-The context loop matches only `serde_json::Value::String` values. An entry like
-`"steps": {"@id": "ex:steps", "@container": "@list"}` is an object, so it is
-silently discarded and the predicate is never registered.
-
-1. Extend the context loop to also match `serde_json::Value::Object`: extract the
-   `@id` string as the predicate IRI and record `@container` in a separate
-   `HashMap<String, String>` (key → container type).
-2. In `json_object_to_ntriples_inner`, when the array branch fires and the
-   predicate's container type is `"@list"`, emit an `rdf:List` cons-cell chain
-   (`rdf:first` / `rdf:rest`) instead of parallel triples. Terminate with
-   `rdf:nil`.
+1. Extend the context loop to also match `serde_json::Value::Object`. Extract the `@id` string as the predicate IRI; record per-predicate metadata in a side table:
+   ```rust
+   struct PredicateMeta {
+       container: Option<String>,   // "@list", "@set", "@language", "@index"
+       datatype:  Option<String>,   // xsd:dateTime, xsd:base64Binary, ...
+       coerce_id: bool,             // @type: @id
+       language:  Option<String>,   // default language tag
+   }
+   ```
+2. In `json_object_to_ntriples_inner`:
+   - When `container == Some("@list")`, emit `rdf:List` chain (`rdf:first` / `rdf:rest`, terminated with `rdf:nil`).
+   - When `coerce_id` is set and the value is a string, emit it as an IRI (`<value>`) instead of a literal.
+   - When `datatype` is set and the value is a primitive, append `^^<datatype-iri>` to the literal.
+   - When `language` is set and the value is a string, append `@lang` to the literal.
+3. The fallback for string-valued context entries (e.g. `"name": "https://schema.org/name"`) remains unchanged.
 
 **Fix 2 — Outbound framing embedder** (`src/framing/embedder.rs`, `build_node_map` and frame matching):
 
-1. When resolving a frame property slot, check if the compacted frame context
-   declares `@container: @list` for that property.
-2. If so, instead of collecting object values directly, traverse the stored
-   `rdf:first` / `rdf:rest` chain rooted at the blank node value and collect
-   objects in chain order.
-3. Emit the collected values as a JSON array in the output node.
+1. When resolving a frame property slot, read the frame's compacted context entry for that property:
+   - If `@container: @list`, traverse the stored `rdf:first` / `rdf:rest` chain rooted at the blank node value and collect objects in chain order; emit as a JSON array.
+   - If `@type: @id`, render IRI object values as bare strings rather than `{"@id": ...}` wrappers.
+   - If `@type: <datatype>`, render typed literals as primitive JSON values (number, boolean, string) rather than `{"@value": ..., "@type": ...}` wrappers, when the datatype matches.
+   - If `@language: <lang>`, render language-tagged strings as bare strings, dropping the wrapper when the language matches.
 
-**Tests**: Add to `tests/pg_regress/sql/jsonld_list_roundtrip.sql`:
-- Ingest a JSON array of strings with `@container: @list`; verify stored triples
-  form an `rdf:List` chain (query `rdf:first` / `rdf:rest` directly).
-- Frame the result with `@container: @list`; verify output array order matches input.
-- Ingest a JSON array of objects with `@container: @list`; verify nested blank
-  nodes are chained and round-trip in order.
-- Ingest an array *without* `@container: @list`; verify it is stored as parallel
-  triples (existing behaviour unchanged).
+**Tests**: Add to `tests/pg_regress/sql/jsonld_context_object_form.sql`:
+- `@container: @list` round-trip:
+  - Ingest `{"steps": ["a", "b", "c"]}` with `"steps": {"@id": "ex:steps", "@container": "@list"}`.
+  - Verify stored triples form `rdf:List` chain (query `rdf:first` / `rdf:rest`).
+  - Frame back with same context; verify output `["a", "b", "c"]` in order.
+  - Repeat with array of nested objects; verify chain order preserved.
+  - Ingest array *without* `@container: @list`; verify parallel triples (existing behaviour unchanged).
+- Datatype hint round-trip:
+  - Ingest `{"ts": "2026-04-28T10:00:00Z"}` with `"ts": {"@id": "ex:ts", "@type": "xsd:dateTime"}`.
+  - Verify stored triple has `^^xsd:dateTime`.
+  - Frame back; verify ISO string returned with correct type retained or dropped per frame.
+- IRI reference round-trip:
+  - Ingest `{"homepage": "https://example.org"}` with `"homepage": {"@id": "ex:homepage", "@type": "@id"}`.
+  - Verify stored object is an IRI (not a literal).
+  - Frame back; verify string output is the original IRI.
+- Language tag round-trip:
+  - Ingest `{"name": "hello"}` with `"name": {"@id": "schema:name", "@language": "en"}`.
+  - Verify stored literal has `@en` tag.
+  - Frame back with same `@language`; verify bare string output.
+- Backward compatibility: Ingest with a context that has only string-valued entries; verify behaviour is byte-identical to v0.71.0.
 
 ---
 
@@ -357,5 +370,32 @@ silently discarded and the predicate is never registered.
 - [ ] GUC-DOC-01: GUC reference doc created.
 - [ ] CITUS-URL-01: URL parsing edge-case tests pass.
 - [ ] JSONLD-NODE-01: `export_jsonld_node()` function exists; recursive strip works on nested blank nodes; pg_regress tests pass; `docs/src/operations/pg-trickle-relay.md` Step 5 updated to use the new function.
-- [ ] BUG-JSONLD-LIST-01: `@container: @list` ingest emits `rdf:List` chain; framing embedder traverses chain in order; round-trip order test passes.
+- [ ] BUG-JSONLD-CONTEXT-01: object-form context entries handled for `@container: @list`, `@type`, `@type: @id`, and `@language`; round-trip tests pass for all four.
 - [ ] All 190+ pg_regress tests pass.
+
+---
+
+## JSON round-trip: known deferred corner cases
+
+With JSONLD-NODE-01 and BUG-JSONLD-CONTEXT-01 landed, the JSON → RDF → JSON
+round-trip handles the bulk of real-world payloads. The following corner cases
+are **deliberately deferred** to a later release; each is independent and does
+not block the relay or HTAP use cases.
+
+| ID | Case | Current behaviour | Workaround |
+|---|---|---|---|
+| RT-01 | Empty array `[]` | Predicate not stored; output key absent | Caller adds `IS NULL → []` post-step |
+| RT-02 | Empty object `{}` | Stored as bare blank node; round-trips to `{}` after recursive strip | None needed for typical use |
+| RT-03 | Multi-graph ingest (`{"@graph": [...]}`) | `json_to_ntriples_and_load()` accepts only a single subject; caller must loop | Loop in pl/pgSQL; outbound `@graph` already supported |
+| RT-04 | Numeric precision (>2^53) | Stored as `xsd:integer`; lossy in JS clients | Caller stringifies; future: `@type: xsd:long` hint |
+| RT-05 | Decimal trailing zeros (`22.50`) | Normalised to `22.5` | Documented; RDF semantic |
+| RT-06 | Float vs integer (`5.0` vs `5`) | serde collapses; first writer wins | Use explicit `@type` in context |
+| RT-07 | Property names with spaces or slashes | Concatenated into malformed IRI under `@vocab` | Validate at ingest (separate ticket) |
+| RT-08 | `null` vs absent | Both produce no triple; indistinguishable on output | RDF has no null |
+| RT-09 | Duplicate keys in source JSON | Last-write-wins (serde) | JSON parser limitation, not RDF |
+| RT-10 | Heterogeneous arrays of mixed types | Works but no test coverage | Add proptest in v0.73.0 |
+
+Items RT-01, RT-03, RT-07 are tracked as separate backlog tickets and slated
+for v0.73.0 consideration. The remaining items are inherent JSON ↔ RDF
+impedance mismatches and will be documented in `docs/src/reference/json-roundtrip.md`
+rather than fixed.

--- a/roadmap/v0.72.0.md
+++ b/roadmap/v0.72.0.md
@@ -27,7 +27,8 @@ With Critical and High findings closed by v0.70.0 and v0.71.0, v0.72.0 works thr
 - GUC cross-reference docs: `docs/src/reference/guc-reference.md` covers `arrow_batch_size`, `export_batch_size`, and `vp_promotion_batch_size`.
 - Citus URL parsing edge-case tests for IPv6, IDN, port-only, and malformed URLs.
 - New `pg_ripple.export_jsonld_node()` SQL function: wraps `export_jsonld_framed()` with subject-IRI lookup, `@graph` unwrap, and recursive keyword strip, eliminating the three-step boilerplate from CDC bridge triggers.
-- Fix `@container: @list` round-trip bug: inbound context parser now handles object-form context entries and emits `rdf:List` cons-cell chains; framing embedder traverses `rdf:first`/`rdf:rest` chains in order.
+- Fix object-form context entries in the inbound JSON-LD parser: enables `@container: @list` (ordered arrays via `rdf:List`), `@type` (datatype hints for typed literals), `@type: @id` (IRI-valued fields), and `@language` (language-tagged strings) — four previously-broken JSON round-trip cases unblocked by one fix. Outbound framing embedder updated to honour the same context features.
+- Documented JSON round-trip corner cases in the spec: empty arrays, multi-graph ingest, IRI-component validation, numeric precision, null-vs-absent, and duplicate keys are tracked as separate backlog items or documented as inherent JSON ↔ RDF impedance mismatches.
 
 ## Assessment findings covered
 

--- a/roadmap/v0.72.0.md
+++ b/roadmap/v0.72.0.md
@@ -26,6 +26,8 @@ With Critical and High findings closed by v0.70.0 and v0.71.0, v0.72.0 works thr
 - Streaming observability: extension `streaming_metrics()` exposed via a `/metrics/extension` route in `pg_ripple_http`.
 - GUC cross-reference docs: `docs/src/reference/guc-reference.md` covers `arrow_batch_size`, `export_batch_size`, and `vp_promotion_batch_size`.
 - Citus URL parsing edge-case tests for IPv6, IDN, port-only, and malformed URLs.
+- New `pg_ripple.export_jsonld_node()` SQL function: wraps `export_jsonld_framed()` with subject-IRI lookup, `@graph` unwrap, and recursive keyword strip, eliminating the three-step boilerplate from CDC bridge triggers.
+- Fix `@container: @list` round-trip bug: inbound context parser now handles object-form context entries and emits `rdf:List` cons-cell chains; framing embedder traverses `rdf:first`/`rdf:rest` chains in order.
 
 ## Assessment findings covered
 
@@ -42,6 +44,7 @@ From [plans/PLAN_OVERALL_ASSESSMENT_10.md](../plans/PLAN_OVERALL_ASSESSMENT_10.m
 - **MF-17**: Datalog/CWB interaction undocumented and untested.
 - **MF-18**: `is_citus_worker_endpoint()` URL parsing untested for edge cases.
 - **MF-19**: Arrow Flight ticket has no replay protection beyond expiry.
+- **UX-01**: CDC bridge triggers require three-step boilerplate (subject decode, `@graph` unwrap, keyword strip) when using `export_jsonld_framed()`.
 
 ---
 

--- a/roadmap/v0.72.0.md
+++ b/roadmap/v0.72.0.md
@@ -29,6 +29,9 @@ With Critical and High findings closed by v0.70.0 and v0.71.0, v0.72.0 works thr
 - New `pg_ripple.export_jsonld_node()` SQL function: wraps `export_jsonld_framed()` with subject-IRI lookup, `@graph` unwrap, and recursive keyword strip, eliminating the three-step boilerplate from CDC bridge triggers.
 - Fix object-form context entries in the inbound JSON-LD parser: enables `@container: @list` (ordered arrays via `rdf:List`), `@type` (datatype hints for typed literals), `@type: @id` (IRI-valued fields), and `@language` (language-tagged strings) — four previously-broken JSON round-trip cases unblocked by one fix. Outbound framing embedder updated to honour the same context features.
 - Documented JSON round-trip corner cases in the spec: empty arrays, multi-graph ingest, IRI-component validation, numeric precision, null-vs-absent, and duplicate keys are tracked as separate backlog items or documented as inherent JSON ↔ RDF impedance mismatches.
+- Targeted ingest fixes for three small JSON round-trip bugs: i64 overflow at ingest no longer silently loses precision (RT-FIX-04B); JSON `5.0` is now stored as `xsd:decimal` rather than collapsing to `xsd:integer` (RT-FIX-06); invalid IRI characters in JSON keys raise a descriptive error instead of producing malformed IRIs (RT-FIX-07).
+- Empty-object regression test added (RT-TEST-02).
+- Property-test generator for heterogeneous JSON arrays added to `PROPTEST-01` (RT-10).
 
 ## Assessment findings covered
 

--- a/roadmap/v0.73.0-full.md
+++ b/roadmap/v0.73.0-full.md
@@ -12,6 +12,7 @@
 | R2RML-DOC-01 | Document `src/r2rml.rs` scope as materialization-only; create `plans/r2rml_virtual.md` tracking item | Required |
 | FEATURE-STATUS-02 | Add `llm_pipeline`, `kge_embeddings` entries to `feature_status()` with accurate status | Required |
 | CONTROL-01 | Update `pg_ripple.control` `comment` field to describe v0.73.0 highlights | Required |
+| JSONLD-INGEST-02 | `pg_ripple.json_ld_load(document, default_graph)`: full JSON-LD document ingest with multi-subject `@graph` support | Required |
 
 ---
 
@@ -106,6 +107,30 @@ Create `CONTRIBUTING.md` at the repository root with:
    - `sparql_nl_to_sparql` → `experimental`
 2. Verify evidence paths exist or use `None`.
 
+### JSONLD-INGEST-02 — Multi-subject JSON-LD document ingest
+
+**Root cause**: Carried forward from v0.72.0 deferred corner case **RT-03**.
+`json_to_ntriples_and_load(payload, subject_iri, ...)` requires a single
+subject IRI parameter, so callers cannot ingest a JSON-LD document that
+contains multiple top-level nodes under `@graph`. The outbound side already
+emits multi-graph documents, so the asymmetry is purely on the ingest path.
+
+**Fix**: Add a new SQL function `pg_ripple.json_ld_load(document JSONB, default_graph TEXT DEFAULT NULL) RETURNS BIGINT` that:
+
+1. Parses `document` as a JSON-LD value using `oxjsonld` (already in the dependency tree via `oxrdf`).
+2. Walks `@graph` (or treats the document as a single node when no `@graph` is present).
+3. For each top-level node, requires an `@id` (raise a descriptive error if missing).
+4. Routes triples to the named graph identified by `@id` at the document's outer level (if present), otherwise to `default_graph`, otherwise to the default graph.
+5. Returns the total number of triples loaded.
+
+**Test**: Add `tests/pg_regress/sql/jsonld_ingest_multi_graph.sql`:
+- Document with `@graph` of 3 nodes; verify all triples loaded under the right subjects.
+- Document with named outer `@id` (a graph IRI); verify triples land in that named graph.
+- Document missing top-level `@id` on a node; verify descriptive error.
+- Backward compat: single-node document with `@id` works without `default_graph`.
+
+**Doc update**: Note in `docs/src/operations/pg-trickle-relay.md` that for multi-subject inbound payloads the trigger should call `json_ld_load()` instead of looping over `json_to_ntriples_and_load()`.
+
 ---
 
 ## Exit criteria
@@ -118,4 +143,5 @@ Create `CONTRIBUTING.md` at the repository root with:
 - [ ] R2RML-DOC-01: R2RML scope documented; tracking issue doc created.
 - [ ] FEATURE-STATUS-02: `llm_pipeline`, `kge_embeddings`, `sparql_nl_to_sparql` in `feature_status()`.
 - [ ] CONTROL-01: `pg_ripple.control` `comment` updated.
+- [ ] JSONLD-INGEST-02: `json_ld_load()` function exists; multi-graph round-trip test passes; relay doc updated.
 - [ ] All 190+ pg_regress tests pass.

--- a/roadmap/v0.73.0.md
+++ b/roadmap/v0.73.0.md
@@ -22,6 +22,7 @@ Assessment 10 Dimension 12 identified several missing ecosystem capabilities tha
 - `src/r2rml.rs` scope documented: the module materializes triples (it is not a virtual graph layer); a future virtual R2RML graph layer is tracked in `plans/r2rml_virtual.md`.
 - `src/llm/` and `src/kge.rs` modules added to `feature_status()` with accurate status values.
 - `pg_ripple.control` `comment` field updated to describe v0.73.0 highlights.
+- New `pg_ripple.json_ld_load(document, default_graph)` SQL function: ingests a full JSON-LD document with `@graph`, walking each top-level node under its declared `@id`. Closes the asymmetry between inbound (single-subject only) and outbound (multi-graph supported) JSON-LD paths.
 
 ## Assessment findings covered
 
@@ -32,6 +33,7 @@ From [plans/PLAN_OVERALL_ASSESSMENT_10.md](../plans/PLAN_OVERALL_ASSESSMENT_10.m
 - **MF-15**: `[Unreleased]` section needs contributor guidance.
 - **MF-20**: `feature_status()` taxonomy has no documented promotion criteria.
 - Low findings: `CONTRIBUTING.md` missing; Helm chart uses `latest` tag; `src/llm/` and `src/kge.rs` not in `feature_status()`; `src/r2rml.rs` scope unclear; `pg_ripple.control` comment stale.
+- **RT-03** (from v0.72.0 deferred corner cases): multi-subject JSON-LD ingest gap.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the manual `jsonb_build_object` outbound conversion in the pg-trickle relay
doc with declarative JSON-LD framing, moves the alert-type literal into the triplestore
via a Datalog rule, and adds two new v0.72.0 roadmap items that address the remaining
boilerplate and a confirmed round-trip bug.

## Changes

**`docs/src/operations/pg-trickle-relay.md`**

- Step 3 Datalog rules: add `ex:alertType(Obs, "high_temperature")` rule so the alert
  category is stored as a literal triple rather than hardcoded in trigger code.
- Step 5 trigger: replace the `jsonb_build_object` + `sensor_inbox` join with
  `export_jsonld_framed()` and a static JSONB frame template. The `@context` maps
  short names to SAREF predicate IRIs; `@id` is the only dynamic piece, appended with
  `||`. The two-step unwrap + strip (`-> '@graph' -> 0` / `- '@type' - '@id'`) removes
  JSON-LD structural keywords; the `alert` field comes from the triplestore, not the
  trigger.
- Prose updated to explain the framing approach and the recursive strip pattern.

**`roadmap/v0.72.0.md` / `roadmap/v0.72.0-full.md`**

- **JSONLD-NODE-01**: plan for `pg_ripple.export_jsonld_node(frame, subject_id, strip)`
  — bundles subject IRI lookup, `@graph` unwrap, and recursive keyword strip into one
  call, eliminating all remaining boilerplate at CDC bridge trigger call sites.
  Includes full signature, parameter table, trigger usage example, and pg_regress test
  plan. Also tracks the doc update (relay doc Step 5 to be updated to use the new
  function once implemented).
- **BUG-JSONLD-LIST-01**: fix `@container: @list` round-trip fidelity, pulled into
  v0.72.0 scope. Two confirmed bugs: (1) `src/bulk_load.rs` context parser silently
  drops object-form context entries so ordered arrays are stored as unordered parallel
  triples; (2) `src/framing/embedder.rs` has no `rdf:first`/`rdf:rest` traversal and
  ignores `@container: @list` in frames. Both fixes specified with test plan.

## Testing

These are documentation and roadmap changes only — no Rust source modified. Verified
by reading the relevant source files (`src/bulk_load.rs`, `src/framing/embedder.rs`,
`src/framing/mod.rs`) to confirm the two BUG-JSONLD-LIST-01 root causes are accurately
described before adding them to the spec.

## Notes

- The relay doc still uses the `export_jsonld_framed()` + manual unwrap/strip pattern
  pending JSONLD-NODE-01 implementation; the roadmap spec explicitly tracks updating
  it once the function ships.
- BUG-JSONLD-LIST-01 was discovered during the JSON round-trip discussion and confirmed
  against the live source; the fix spec is in `v0.72.0-full.md`.
