### PR TITLE
docs: add JSON-MAPPING-01 to v0.73.0 roadmap (bidirectional JSON mapping)

### DIFF
--- a/roadmap/v0.73.0-full.md
+++ b/roadmap/v0.73.0-full.md
@@ -13,6 +13,7 @@
 | FEATURE-STATUS-02 | Add `llm_pipeline`, `kge_embeddings` entries to `feature_status()` with accurate status | Required |
 | CONTROL-01 | Update `pg_ripple.control` `comment` field to describe v0.73.0 highlights | Required |
 | JSONLD-INGEST-02 | `pg_ripple.json_ld_load(document, default_graph)`: full JSON-LD document ingest with multi-subject `@graph` support | Required |
+| JSON-MAPPING-01 | `pg_ripple.register_json_mapping(name, context, shape)`: named bidirectional mapping; derives ingest context and frame from one registration; optional SHACL shape drives nesting and datatype constraints | Required |
 
 ---
 
@@ -131,6 +132,118 @@ emits multi-graph documents, so the asymmetry is purely on the ingest path.
 
 **Doc update**: Note in `docs/src/operations/pg-trickle-relay.md` that for multi-subject inbound payloads the trigger should call `json_ld_load()` instead of looping over `json_to_ntriples_and_load()`.
 
+### JSON-MAPPING-01 — Named bidirectional JSON mapping
+
+**Root cause**: UX-02. The relay pattern requires writing the same IRI–term
+correspondence twice: once as a context map in the ingest trigger and once as
+a frame template in the export trigger. They are the same information and drift
+independently when a schema changes. A registered mapping stores it once and
+generates both sides at call time.
+
+**Catalog table** (`_pg_ripple.json_mappings`):
+
+```sql
+CREATE TABLE _pg_ripple.json_mappings (
+    name       TEXT PRIMARY KEY,
+    context    JSONB NOT NULL,       -- JSON-LD @context object
+    shape_iri  TEXT,                 -- optional: IRI of a registered sh:NodeShape
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+**SQL API**:
+
+```sql
+-- Register (or replace) a mapping. When shape_iri is provided, validates
+-- that every context term has a corresponding sh:property in the shape,
+-- and that every sh:property with a sh:name annotation has a context entry.
+-- Raises an error listing mismatches to prevent silent divergence.
+pg_ripple.register_json_mapping(
+    name      TEXT,
+    context   JSONB,
+    shape_iri TEXT DEFAULT NULL
+) RETURNS VOID
+
+-- Ingest a JSON payload using a named mapping. Equivalent to
+-- json_to_ntriples_and_load() but derives the context from the registry.
+pg_ripple.ingest_json(
+    payload     JSONB,
+    subject_iri TEXT,
+    mapping     TEXT,
+    graph_iri   TEXT DEFAULT NULL
+) RETURNS BIGINT
+
+-- Export a single node using a named mapping. Equivalent to
+-- export_jsonld_node() but derives the frame from the registry.
+-- When a shape is registered, nested sh:node structures are followed
+-- automatically to produce the correct frame nesting.
+pg_ripple.export_json_node(
+    subject_id BIGINT,
+    mapping    TEXT,
+    strip      TEXT[] DEFAULT ARRAY['@type', '@id']
+) RETURNS JSONB
+```
+
+**Deriving the frame from context + shape**:
+
+1. Start from the `@context` entries to get term → IRI mappings.
+2. For each IRI, look up the corresponding `sh:property` in the shape (if registered).
+3. If the property has `sh:node <NestedShape>`, recurse into `<NestedShape>` to build the nested frame object. No separate frame parameter needed.
+4. If the property has `sh:datatype`, carry the datatype into the frame context entry (enabling BUG-JSONLD-CONTEXT-01's `@type` annotation automatically).
+5. If the property has `sh:minCount 0`, mark the frame slot as optional (include if present, omit if absent — already the default frame behaviour).
+6. The resulting frame is constructed in-memory at call time from the catalog row; cache it in the LRU plan cache keyed by `(mapping_name, shape_version)`.
+
+**SHACL consistency check at registration**:
+
+When `shape_iri` is provided, `register_json_mapping` runs a SPARQL query over
+the shape graph to collect all `sh:property / sh:path` IRIs and their
+`sh:name` annotations, then compares with the context entries:
+
+- **Context term with no shape property**: warning (the field will be ingested but not validated).
+- **Shape property with no context term**: warning (the field will be stored but never appear in outbound documents).
+- **Datatype mismatch** between `sh:datatype` and a `@type` annotation in the context: error.
+
+Warnings are raised via `pgrx::warning!` and recorded in
+`_pg_ripple.json_mapping_warnings (mapping_name, kind, detail)` for
+post-registration inspection.
+
+**Typical relay trigger usage** (after JSON-MAPPING-01):
+
+```sql
+-- Register once, outside the trigger
+SELECT pg_ripple.register_json_mapping(
+    name      => 'saref_measurement',
+    context   => '{
+        "device": "https://saref.etsi.org/core/measurementMadeBy",
+        "temp":   "https://saref.etsi.org/core/hasValue",
+        "unit":   "https://qudt.org/schema/qudt/unit",
+        "ts":     "https://saref.etsi.org/core/hasTimestamp",
+        "alert":  "https://example.org/alertType"
+    }'::jsonb,
+    shape_iri => 'https://example.org/ObservationShape'
+);
+
+-- Inbound trigger: one line
+PERFORM pg_ripple.ingest_json(NEW.payload, subject_iri, mapping => 'saref_measurement');
+
+-- Outbound trigger: one line
+NEW.payload := pg_ripple.export_json_node(subject_id => NEW.s, mapping => 'saref_measurement');
+```
+
+**Implementation location**:
+- Catalog DDL: `sql/pg_ripple--0.72.0--0.73.0.sql`
+- Rust: `src/json_mapping.rs` (new file) — registration, validation, and frame derivation; `ingest_json` and `export_json_node` thin wrappers calling existing ingest and framing paths.
+
+**Tests**: Add `tests/pg_regress/sql/json_mapping.sql`:
+- Register a mapping without a shape; ingest and export round-trip.
+- Register a mapping with a shape; verify derived frame nesting matches manual equivalent.
+- Register a mapping with a shape; verify datatype mismatch raises an error.
+- Register a mapping with a shape; verify missing-term warnings are written to `_pg_ripple.json_mapping_warnings`.
+- `export_json_node(mapping => ...)` produces output identical to the equivalent `export_jsonld_node(frame => ...)` call.
+- Update a mapping via a second `register_json_mapping` call; verify cache is invalidated and subsequent exports reflect the new context.
+
+**Doc update**: Update `docs/src/operations/pg-trickle-relay.md` to show `register_json_mapping` + `ingest_json` + `export_json_node` as the recommended bidirectional relay pattern; retain the explicit frame approach as the low-level alternative.
+
 ---
 
 ## Exit criteria
@@ -144,4 +257,5 @@ emits multi-graph documents, so the asymmetry is purely on the ingest path.
 - [ ] FEATURE-STATUS-02: `llm_pipeline`, `kge_embeddings`, `sparql_nl_to_sparql` in `feature_status()`.
 - [ ] CONTROL-01: `pg_ripple.control` `comment` updated.
 - [ ] JSONLD-INGEST-02: `json_ld_load()` function exists; multi-graph round-trip test passes; relay doc updated.
+- [ ] JSON-MAPPING-01: `register_json_mapping()` and `ingest_json()` / `export_json_node()` exist; SHACL-derived nesting works; consistency check fires on mismatch; pg_regress tests pass; relay doc updated to use named mapping.
 - [ ] All 190+ pg_regress tests pass.

--- a/roadmap/v0.73.0-full.md
+++ b/roadmap/v0.73.0-full.md
@@ -140,6 +140,32 @@ a frame template in the export trigger. They are the same information and drift
 independently when a schema changes. A registered mapping stores it once and
 generates both sides at call time.
 
+**Scope and relationship to RML**:
+
+RML (the W3C community spec generalising R2RML to JSON/CSV/XML) covers the
+inbound direction comprehensively — JSONPath extraction, computed subject IRIs
+from templates, multi-source joins via `rr:parentTriplesMap`, datatype coercion,
+and ordered lists (RML 2.0 `rml:gather`). pg_ripple already exposes R2RML via
+`src/r2rml.rs`. `register_json_mapping` is **not** a replacement for RML.
+
+The two serve different points on the complexity curve:
+
+| Scenario | Use |
+|---|---|
+| Flat-to-moderately-nested JSON payloads in CDC triggers; full round-trip (ingest + export) needed; SHACL shape already registered | `register_json_mapping` |
+| Complex ETL: computed IRIs from templates, JSONPath extraction, multi-source joins, batch file processing | RML / `r2rml` |
+
+`register_json_mapping` is essentially **"JSON-LD context as a storable database
+object with a derived reverse"**. JSON-LD expansion already *is* the inbound
+direction; compaction is the outbound direction. Making the context storable and
+cacheable — and associating it with a SHACL shape for nesting derivation and
+consistency checking — is the novel contribution. RML has no export direction and
+no SHACL integration.
+
+For payloads that require JSONPath or computed IRIs, callers should author a full
+RML mapping. For everything else, `register_json_mapping` is sufficient and
+significantly simpler.
+
 **Catalog table** (`_pg_ripple.json_mappings`):
 
 ```sql

--- a/roadmap/v0.73.0.md
+++ b/roadmap/v0.73.0.md
@@ -23,6 +23,7 @@ Assessment 10 Dimension 12 identified several missing ecosystem capabilities tha
 - `src/llm/` and `src/kge.rs` modules added to `feature_status()` with accurate status values.
 - `pg_ripple.control` `comment` field updated to describe v0.73.0 highlights.
 - New `pg_ripple.json_ld_load(document, default_graph)` SQL function: ingests a full JSON-LD document with `@graph`, walking each top-level node under its declared `@id`. Closes the asymmetry between inbound (single-subject only) and outbound (multi-graph supported) JSON-LD paths.
+- New `pg_ripple.register_json_mapping(name, context, shape)` SQL function: stores a named bidirectional JSON↔RDF mapping. The engine derives both the ingest context map and the outbound frame template from a single registered object, eliminating the duplication of writing the same IRI–term correspondence twice. When a SHACL shape is referenced, nested node structure and datatype constraints are derived automatically from `sh:property` / `sh:node` without a separate frame; SHACL and mapping are validated for consistency at registration time.
 
 ## Assessment findings covered
 
@@ -34,6 +35,7 @@ From [plans/PLAN_OVERALL_ASSESSMENT_10.md](../plans/PLAN_OVERALL_ASSESSMENT_10.m
 - **MF-20**: `feature_status()` taxonomy has no documented promotion criteria.
 - Low findings: `CONTRIBUTING.md` missing; Helm chart uses `latest` tag; `src/llm/` and `src/kge.rs` not in `feature_status()`; `src/r2rml.rs` scope unclear; `pg_ripple.control` comment stale.
 - **RT-03** (from v0.72.0 deferred corner cases): multi-subject JSON-LD ingest gap.
+- **UX-02** (from v0.72.0 discussion): bidirectional JSON mapping boilerplate — same IRI–term correspondence written twice for ingest and export triggers.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `JSON-MAPPING-01` to the v0.73.0 roadmap: a named bidirectional
JSON↔RDF mapping that eliminates the relay pattern's main remaining
boilerplate — writing the same IRI–term correspondence twice, once for
ingest and once for export.

This follows on from PR #40 (merged), which introduced the declarative
framing approach. That PR left the ingest and export triggers with an
identical `@context` duplicated in two places. This item stores it once
and generates both sides at call time.

## Changes

**`roadmap/v0.73.0.md`**

- New headline outcome: `register_json_mapping()` with optional SHACL shape
  reference; derives both ingest context and frame automatically.
- New assessment finding: UX-02 (bidirectional mapping boilerplate).

**`roadmap/v0.73.0-full.md`**

- `JSON-MAPPING-01` added to goals table.
- Full deliverable spec: catalog table DDL, three SQL functions
  (`register_json_mapping`, `ingest_json`, `export_json_node`), SHACL
  shape integration design (sh:node recursion drives frame nesting;
  sh:datatype flows to @type annotations), consistency check behaviour
  (warnings to `json_mapping_warnings`, errors on datatype conflicts),
  LRU plan cache keying, implementation location, and a six-case pg_regress
  test plan.
- Exit criterion added.

## Testing

Documentation and roadmap change only. No Rust source modified.

## Notes

- The relay doc update (showing `ingest_json` + `export_json_node` as the
  recommended pattern) is tracked inside the JSON-MAPPING-01 spec and will
  be done alongside the implementation in v0.73.0.
- SHACL shape integration is optional — callers without a registered shape
  get the flat-context behaviour; the shape adds nesting derivation and
  consistency checking on top.
