### PR TITLE
roadmap: add v0.79.0 — Query Engine Completeness (WCOJ Leapfrog Triejoin + sh:SPARQLRule)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ One release remains on the path to v1.0.0.
 
 The v0.64.0–v0.76.0 Assessment Remediation & Production Polish sequence is complete. Key milestones: honest feature-status SQL API (`feature_status()`), GitHub Actions SHA pinning and Docker release digest integrity, CONSTRUCT writeback incremental delta maintenance, true portal-based SPARQL cursor streaming (bounded memory), HMAC-SHA256 signed Arrow Flight tickets with nonce replay protection, real Arrow IPC streaming in `pg_ripple_http`, 72-hour soak test artifacts, security audit closure, public benchmark baselines, upgrade and backup acceptance tests, operator runbooks, a mandatory release evidence dashboard, module restructuring along single-responsibility boundaries (v0.69.0), sub-transaction savepoint/rollback support (v0.72.0), SPARQL live subscription API with SSE (v0.73.0), JSON↔RDF mapping registry (v0.73.0), mutation journal wired through Datalog inference (v0.74.0), VP promotion plan-cache invalidation and interrupted-promotion recovery (v0.74.0), Citus and Arrow CI integration jobs (v0.75.0), RLS policy hash widened to XXH3-128, reproducible toolchain pin (v0.76.0), 227 regression tests (v0.76.0), and benchmark baselines refreshed to current HTAP performance levels (v0.76.0).
 
+### v0.79.0 — Query Engine Completeness
+
+Before the production release, v0.79.0 closes the two remaining known limitations: a true **Leapfrog Triejoin executor** for Worst-Case Optimal Joins (WCOJ), replacing the current planner-hint-only mode; and full **`sh:SPARQLRule`** evaluation, allowing SHACL Advanced Features forward-chaining rules to materialise triples via native SPARQL CONSTRUCT queries. When both are delivered, every row in `pg_ripple.feature_status()` will show `implemented` and the "Known limitations" table will be removed from the README.
+
 ### v1.0.0 — Production Release
 
 The final milestone: full API and documentation freeze, long-term support commitment, and public production dossier. All conformance suites (SPARQL 1.1, SHACL Core, OWL 2 RL, LUBM) remain required gates; performance regression CI and the release evidence dashboard are mandatory artifacts.
@@ -358,9 +362,8 @@ The following features are available but have documented limitations in the curr
 
 | Feature | Status | Detail |
 |---|---|---|
-| **Arrow Flight bulk export** | Implemented | `/flight/do_get` streams tombstone-excluded Arrow IPC record batches with HMAC-SHA256 signed tickets and nonce replay protection. Citus and Arrow CI integration tests run in dedicated CI jobs (`citus-integration`, `arrow-integration`). |
-| **WCOJ (Worst-Case Optimal Joins)** | Planner hint | WCOJ re-orders cyclic BGP joins at plan time. A true Leapfrog Triejoin executor is not implemented. |
-| **SHACL-SPARQL rules (`sh:SPARQLRule`)** | Not supported | When detected, the extension emits a WARNING (PT481) and skips the rule. Full `sh:SPARQLRule` support is targeted for v1.0.0. `sh:TripleRule` and `sh:SPARQLConstraint` are fully supported. |
+| **WCOJ (Worst-Case Optimal Joins)** | Planner hint | WCOJ re-orders cyclic BGP joins at plan time. A true Leapfrog Triejoin executor is planned for v0.79.0 (WCOJ-LFTI-01). |
+| **SHACL-SPARQL rules (`sh:SPARQLRule`)** | Planned (v0.79.0) | When detected, the extension emits a WARNING (PT481) and skips the rule. Full `sh:SPARQLRule` support is planned for v0.79.0 (SHACL-SPARQL-01). `sh:TripleRule` and `sh:SPARQLConstraint` are fully supported. |
 | **Citus, pgvector, pg_trickle** | Optional | Citus, pgvector, and pg_trickle are optional dependencies. Dependent features degrade gracefully when these extensions are not installed. |
 
 These are not bugs — they are known partial implementations. All limitations are surfaced in `pg_ripple.feature_status()`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,6 +146,12 @@
 |---------|-------|--------|-------|-------------- |
 | [v0.77.0 + v0.78.0](roadmap/v0.77.0-full.md) | **v0.77.0 — Bidirectional Integration Primitives** (source attribution, conflict resolution with echo-aware `normalize`, late-binding IRI rewrite, sparse-CAS events, linkback with target-assigned IDs, pg-trickle outbox/inbox transport) + **v0.78.0 — Bidirectional Integration Operations** (write-side outbox policy, new-events-only schema evolution, per-subscription side-band auth, write-time redaction, audit, property/chaos tests, reconciliation toolkit, ops surface). Both ship together. **BIDI-SPEC-01:** non-blocking draft RDF Bidirectional Integration Profile v1 for broader ecosystem review. | Planned | Large | [v0.77.0](roadmap/v0.77.0-full.md), [v0.78.0](roadmap/v0.78.0-full.md) |
 
+### Query Engine Completeness (v0.79.0)
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|-------------- |
+| [v0.79.0](roadmap/v0.79.0.md) | Close the last two known query-engine limitations: true Leapfrog Triejoin executor for Worst-Case Optimal Joins (WCOJ-LFTI-01) and full `sh:SPARQLRule` evaluation (SHACL-SPARQL-01). Removes the "Known limitations" table from the README; all `feature_status()` rows become `implemented`. | Planned | Medium | [Full details](roadmap/v0.79.0-full.md) |
+
 #### PLAN_OVERALL_ASSESSMENT_11 coverage map
 
 Every finding and recommendation from [plans/PLAN_OVERALL_ASSESSMENT_11.md](plans/PLAN_OVERALL_ASSESSMENT_11.md) is assigned to one or more roadmap milestones:
@@ -406,6 +412,15 @@ v0.72          ─── Architecture hardening: mutation journal SAVEPOINT safe
        │
 v0.73          ─── SPARQL 1.2 tracking, live subscription API (SSE/WebSocket),
                │   feature taxonomy, CONTRIBUTING.md, Helm chart SHA, R2RML docs
+       │
+v0.74–v0.76    ─── Assessment 11 remediation & production polish: evidence truthfulness,
+               │   mutation journal wiring, RLS hash widening, toolchain pin, 227 regression tests
+       │
+v0.77–v0.78    ─── Bidirectional integration: source attribution, CAS conflict resolution,
+               │   linkback rendezvous, outbox policy, per-subscription auth, redaction, audit
+       │
+v0.79          ─── Query engine completeness: true Leapfrog Triejoin executor (WCOJ),
+               │   full sh:SPARQLRule evaluation; all feature_status() rows → implemented
        │
 v1.0.0         ─── Stable release: 72-hour continuous load test, third-party security audit, documentation freeze, public benchmarks
        │

--- a/roadmap/v0.79.0-full.md
+++ b/roadmap/v0.79.0-full.md
@@ -1,0 +1,134 @@
+# v0.79.0 Full Details — Query Engine Completeness
+
+**Parent:** [v0.79.0.md](v0.79.0.md)  
+**Status: Planned** | **Scope: Medium**
+
+---
+
+## Background
+
+Two items have appeared in the `README.md` "Known limitations" table since v0.62.0 (WCOJ) and v0.53.0 (SHACL-SPARQL). Both were deferred to v1.0.0 in previous assessments because they are non-trivial to implement correctly and the rest of the query engine was more urgent.
+
+After v0.78.0, these are the only two items in `feature_status()` that are not `implemented`. Closing them in v0.79.0 means v1.0.0 can focus entirely on production hardening, security audit, and documentation freeze without carrying known feature gaps.
+
+---
+
+## WCOJ-LFTI-01 — Leapfrog Triejoin Executor
+
+### Current state
+
+`src/sparql/wcoj.rs` implements the WCOJ *planner*: it detects cyclic BGP join patterns and re-orders the joins to minimize intermediate result size (worst-case optimal join *order*). The reordered plan is still executed by PostgreSQL's hash-join and nested-loop machinery, so the worst-case complexity guarantee is not achieved in practice for dense cyclic graphs.
+
+### What changes
+
+Implement a true Leapfrog Triejoin (LFTI) executor inside `src/sparql/wcoj.rs`:
+
+**Trie iterator interface**
+- `TrieIterator` trait with `open()`, `up()`, `next()`, `seek(key)`, `at_end()` methods.
+- One `VpTableTrieIterator` per VP table scan that wraps a PostgreSQL cursor (SPI) and exposes the trie interface over the `(s, o)` B-tree index.
+
+**Leapfrog join**
+- `LeapfrogJoin` over a set of `TrieIterator`s sharing a join attribute.
+- `LeapfrogTriejoin` composes `LeapfrogJoin` instances one per join attribute in the variable-order chosen by the planner.
+
+**Integration**
+- `src/sparql/execute.rs` checks whether the compiled plan contains a WCOJ node. If yes, it invokes `LeapfrogTriejoin::execute()` directly (SPI cursors) rather than emitting SQL for PostgreSQL to execute.
+- Fallback: if any iterator cannot be opened (e.g. the predicate VP table does not exist), the system falls back to the existing SQL hash-join path.
+
+**Feature status**
+- `feature_status()` row `wcoj` updated from `planner_hint` to `implemented`.
+
+### Deliverables
+
+| ID | Deliverable |
+|---|---|
+| WCOJ-LFTI-01a | `TrieIterator` trait + `VpTableTrieIterator` in `src/sparql/wcoj.rs` |
+| WCOJ-LFTI-01b | `LeapfrogJoin` + `LeapfrogTriejoin` structs |
+| WCOJ-LFTI-01c | Integration in `src/sparql/execute.rs` with hash-join fallback |
+| WCOJ-LFTI-01d | Regression tests: 3-clique, 4-clique, triangle counting, social-network path |
+| WCOJ-LFTI-01e | Benchmark: WCOJ vs hash-join on synthetic cyclic dataset (10 M edges) |
+| WCOJ-LFTI-01f | `feature_status()` entry updated |
+
+---
+
+## SHACL-SPARQL-01 — Full `sh:SPARQLRule` Support
+
+### Current state
+
+`src/shacl/af_rules.rs` detects `sh:SPARQLRule` nodes in the shapes graph, emits `WARNING` (error code PT481), and skips the rule. `sh:TripleRule` (SHACL-AF triple rules) and `sh:SPARQLConstraint` are fully implemented.
+
+### What changes
+
+Implement `sh:SPARQLRule` evaluation:
+
+**Parsing**
+- `src/shacl/af_rules.rs`: extend `parse_sparql_rule()` to extract the `sh:construct` SPARQL body and the optional `sh:prefixes` declarations.
+
+**Compilation**
+- Prepend prefix declarations to the SPARQL body, then call the existing SPARQL parser (`src/sparql/parse.rs`) to produce a CONSTRUCT algebra tree.
+- Encode any constants in the CONSTRUCT template against the dictionary.
+
+**Execution**
+- Call the existing SPARQL CONSTRUCT executor (`src/sparql/execute.rs → execute_construct`) with the compiled query.
+- Materialise the resulting triples into the target graph via the standard VP insert path (`src/storage/ops.rs`).
+
+**Integration with SHACL validation pipeline**
+- `src/shacl/validator.rs`: after synchronous constraint checking, run all `sh:SPARQLRule` rules in topological order (same scheduler as CONSTRUCT writeback, `src/construct_rules/scheduler.rs`).
+- `sh:order` is respected for execution order within a shapes graph.
+
+**Integration with CONSTRUCT writeback**
+- `sh:SPARQLRule` rules whose target graph matches an existing CWB pipeline are registered as CWB rules (same delta-maintenance path, `src/construct_rules/delta.rs`). This is opt-in via `pg_ripple.shacl_rule_cwb = true` (default false).
+
+**Feature status**
+- `feature_status()` row `shacl_sparql_rule` updated from `warning_and_skip` to `implemented`.
+- Remove PT481 WARNING from the hot path; emit at most once per session (de-dup).
+
+### Deliverables
+
+| ID | Deliverable |
+|---|---|
+| SHACL-SPARQL-01a | `parse_sparql_rule()` extended to extract SPARQL body + prefixes |
+| SHACL-SPARQL-01b | Compilation via existing SPARQL CONSTRUCT path |
+| SHACL-SPARQL-01c | `sh:order`-respecting execution loop in `validator.rs` |
+| SHACL-SPARQL-01d | Optional CWB integration (`pg_ripple.shacl_rule_cwb` GUC) |
+| SHACL-SPARQL-01e | Regression tests: forward-chaining shape rules, `sh:order` ordering, interaction with `sh:SPARQLConstraint` in the same shapes graph |
+| SHACL-SPARQL-01f | `feature_status()` entry updated; PT481 de-dup |
+
+---
+
+## README-LIMITS-01 — Remove Known Limitations Table
+
+Once WCOJ-LFTI-01 and SHACL-SPARQL-01 are delivered and all `feature_status()` rows are `implemented`:
+
+- Remove the "Known limitations in vX.Y.Z" section from `README.md`.
+- Replace it with a one-line note: "All features listed above are fully implemented. Run `SELECT * FROM pg_ripple.feature_status()` for the machine-readable status surface."
+
+The Citus/pgvector/pg_trickle "optional" row is not a limitation; it is a design choice and will be noted in the Architecture section instead.
+
+---
+
+## Schema changes
+
+None — all changes are in the Rust implementation only. `sh:SPARQLRule` uses existing VP tables and the existing dictionary.
+
+Migration: `sql/pg_ripple--0.78.0--0.79.0.sql` (empty, no schema changes).
+
+---
+
+## Test plan
+
+| Test file | What it covers |
+|---|---|
+| `tests/pg_regress/sql/v079_wcoj.sql` | 3-clique, 4-clique, triangle counting, LFTI vs hash-join result equivalence |
+| `tests/pg_regress/sql/v079_shacl_sparql_rule.sql` | Forward-chaining sh:SPARQLRule, sh:order, sh:prefixes, interaction with sh:SPARQLConstraint |
+| `tests/pg_regress/sql/v079_features.sql` | feature_status() rows for wcoj and shacl_sparql_rule both show 'implemented' |
+
+---
+
+## Risk and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| LFTI cursor performance regression on simple patterns | Fallback to SQL hash-join when estimated VP table cardinality < threshold (GUC `pg_ripple.wcoj_min_cardinality`) |
+| `sh:SPARQLRule` infinite loop (rules firing each other) | Iteration cap per validation cycle (`pg_ripple.shacl_rule_max_iterations` GUC, default 100); error on cap reached |
+| `sh:SPARQLRule` CONSTRUCT body with syntax errors | Caught at `load_shacl()` time, not at validation time; `load_shacl()` returns an error with the offending rule IRI |

--- a/roadmap/v0.79.0.md
+++ b/roadmap/v0.79.0.md
@@ -1,0 +1,23 @@
+# v0.79.0 - Query Engine Completeness
+
+> **Full technical details:** [v0.79.0-full.md](v0.79.0-full.md)
+
+**Status: Planned** | **Scope: Medium**
+
+> v0.79.0 closes the two remaining known query-engine limitations that have been carried since v0.62.0: full Leapfrog Triejoin execution for Worst-Case Optimal Joins, and native `sh:SPARQLRule` evaluation. Both were previously deferred to v1.0.0 but are tractable before the production release. Resolving them now removes the limitations table from the README and allows v1.0.0 to focus entirely on stability, security, and documentation freeze.
+
+---
+
+## What is this?
+
+After v0.78.0 delivers bidirectional integration operations, one pre-1.0 release remains to close the last two "not fully implemented" entries in `pg_ripple.feature_status()`:
+
+1. **Leapfrog Triejoin (WCOJ)** — WCOJ currently re-orders cyclic BGP joins at plan time (planner hint) but executes them with ordinary hash joins. A true Leapfrog Triejoin executor processes all join attributes simultaneously using trie-structured iterators, achieving the worst-case optimal guarantee on cyclic and deep graph patterns.
+
+2. **`sh:SPARQLRule`** — SHACL Advanced Features `sh:SPARQLRule` rules are detected, a WARNING (PT481) is emitted, and the rule is skipped. `sh:TripleRule` and `sh:SPARQLConstraint` are fully supported. Full `sh:SPARQLRule` implementation evaluates the SPARQL SELECT as a native query against the VP store and materialises the resulting triples.
+
+## Headline outcomes
+
+- **WCOJ-LFTI-01** — True Leapfrog Triejoin executor for cyclic BGP joins. Plan hint mode becomes the fallback only when the trie iterator cannot be built (e.g. unbounded predicates). Regression tests for cyclic patterns (cliques, paths, social-network triangles). Benchmark comparison vs hash-join baseline.
+- **SHACL-SPARQL-01** — Full `sh:SPARQLRule` support: parse the `sh:construct`/`sh:select` body, compile to a SPARQL query via the existing SPARQL engine, materialise result triples into the target graph. Integrated with the SHACL validation pipeline and CONSTRUCT writeback scheduler. Regression tests covering forward-chaining shape rules. `feature_status()` updated.
+- **README-LIMITS-01** — Remove the "Known limitations" table from README.md once both items above are delivered. The section is replaced with a brief note directing users to `pg_ripple.feature_status()` for the machine-readable surface.


### PR DESCRIPTION
## Summary

Introduces **v0.79.0 — Query Engine Completeness** to the roadmap, targeting the two remaining items listed in the README "Known limitations" table. Moving these into a planned release with full technical specs means they are no longer open-ended deferrals to v1.0.0 — they have a clear milestone, implementation design, and test plan. v1.0.0 can then focus entirely on production hardening, security audit, and documentation freeze.

## Changes

### New roadmap documents
- `roadmap/v0.79.0.md` — summary stub with theme, status, headline outcomes
- `roadmap/v0.79.0-full.md` — full technical specification covering:
  - **WCOJ-LFTI-01**: `TrieIterator` trait + `VpTableTrieIterator`, `LeapfrogJoin` / `LeapfrogTriejoin` structs, integration in `execute.rs` with hash-join fallback, benchmark vs hash-join on a 10 M-edge cyclic dataset, GUC `pg_ripple.wcoj_min_cardinality` fallback threshold
  - **SHACL-SPARQL-01**: `sh:construct` body + `sh:prefixes` parsing, compilation via existing SPARQL CONSTRUCT path, `sh:order`-respecting execution loop in `validator.rs`, optional CWB integration via `pg_ripple.shacl_rule_cwb` GUC, PT481 de-dup
  - **README-LIMITS-01**: remove the "Known limitations" table once both items are `implemented` in `feature_status()`
  - Deliverable table, risk/mitigation matrix, test plan, migration note (empty SQL script)

### ROADMAP.md
- New `### Query Engine Completeness (v0.79.0)` section and table row after v0.77.0 + v0.78.0
- ASCII timeline updated with v0.74–v0.76, v0.77–v0.78, and v0.79 steps (previously jumped directly from v0.73 to v1.0.0)

### README.md
- **WCOJ row**: "not implemented" → "planned for v0.79.0 (WCOJ-LFTI-01)"
- **SHACL-SPARQL row**: "targeted for v1.0.0" → "planned for v0.79.0 (SHACL-SPARQL-01)"
- **Arrow Flight row removed**: status was already "Implemented" — not a limitation
- **"Where we're headed"** gains a `v0.79.0` paragraph explaining both deliverables

## Testing

No code changes in this PR — roadmap and documentation only. The implementation work will land in the v0.79.0 development branch.

## Notes

- Both WCOJ-LFTI-01 and SHACL-SPARQL-01 are self-contained Rust changes with no schema migrations required.
- The Arrow Flight row was removed from the limitations table because its status was already "Implemented" — it was left over from an earlier draft of the table.
- The Citus/pgvector/pg_trickle "optional" row is retained as it describes a design choice, not a gap.
