### PR TITLE
feat(confidence): v0.108.0 — Bayesian confidence updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/trickle-labs/pg_ripple:0.107.0
+    image: ghcr.io/trickle-labs/pg_ripple:0.108.0
     ports:
       - "5432:5432"
     environment:
@@ -47,7 +47,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/trickle-labs/pg_ripple:0.107.0
+    image: ghcr.io/trickle-labs/pg_ripple:0.108.0
     entrypoint: ["/usr/local/bin/pg_ripple_http"]
     ports:
       - "7878:7878"

--- a/pg_ripple.cdx.json
+++ b/pg_ripple.cdx.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:e8dff20f-5bbe-460b-ae66-835a7bf62ac1",
+  "serialNumber": "urn:uuid:0d12b259-42d0-40c2-bec8-5720a4826a2e",
   "metadata": {
-    "timestamp": "2026-05-11T13:14:54.465263000Z",
+    "timestamp": "2026-05-11T16:46:04.625051000Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "library",
-      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.107.0",
+      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.108.0",
       "name": "pg_ripple",
-      "version": "0.107.0",
+      "version": "0.108.0",
       "description": "High-performance RDF triple store with native SPARQL query execution for PostgreSQL 18",
       "scope": "required",
       "licenses": [
@@ -24,7 +24,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/pg_ripple@0.107.0?download_url=file://.",
+      "purl": "pkg:cargo/pg_ripple@0.108.0?download_url=file://.",
       "externalReferences": [
         {
           "type": "vcs",
@@ -34,10 +34,10 @@
       "components": [
         {
           "type": "library",
-          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.107.0 bin-target-0",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.108.0 bin-target-0",
           "name": "pg_ripple",
-          "version": "0.107.0",
-          "purl": "pkg:cargo/pg_ripple@0.107.0?download_url=file://.#src/lib.rs"
+          "version": "0.108.0",
+          "purl": "pkg:cargo/pg_ripple@0.108.0?download_url=file://.#src/lib.rs"
         }
       ]
     },
@@ -6201,7 +6201,7 @@
   ],
   "dependencies": [
     {
-      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.107.0",
+      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.108.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",

--- a/pg_ripple_http/pg_ripple_http.cdx.json
+++ b/pg_ripple_http/pg_ripple_http.cdx.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:b714a761-0b6e-4674-bb9b-5502271e3830",
+  "serialNumber": "urn:uuid:2af3bedc-e65f-47d0-9a7a-ff357e1239a2",
   "metadata": {
-    "timestamp": "2026-05-11T13:14:54.469145000Z",
+    "timestamp": "2026-05-11T16:46:04.628266000Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.107.0",
+      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.108.0",
       "name": "pg_ripple_http",
-      "version": "0.107.0",
+      "version": "0.108.0",
       "description": "SPARQL 1.1 Protocol HTTP endpoint for pg_ripple — connects PostgreSQL 18 RDF triple store to the web",
       "scope": "required",
       "licenses": [
@@ -24,7 +24,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/pg_ripple_http@0.107.0?download_url=file://.",
+      "purl": "pkg:cargo/pg_ripple_http@0.108.0?download_url=file://.",
       "externalReferences": [
         {
           "type": "vcs",
@@ -34,10 +34,10 @@
       "components": [
         {
           "type": "application",
-          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.107.0 bin-target-0",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.108.0 bin-target-0",
           "name": "pg_ripple_http",
-          "version": "0.107.0",
-          "purl": "pkg:cargo/pg_ripple_http@0.107.0?download_url=file://.#src/main.rs"
+          "version": "0.108.0",
+          "purl": "pkg:cargo/pg_ripple_http@0.108.0?download_url=file://.#src/main.rs"
         }
       ]
     },
@@ -7570,7 +7570,7 @@
   ],
   "dependencies": [
     {
-      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.107.0",
+      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.108.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#arrow@58.2.0",
         "registry+https://github.com/rust-lang/crates.io-index#axum@0.8.9",

--- a/sbom.json
+++ b/sbom.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:e8dff20f-5bbe-460b-ae66-835a7bf62ac1",
+  "serialNumber": "urn:uuid:0d12b259-42d0-40c2-bec8-5720a4826a2e",
   "metadata": {
-    "timestamp": "2026-05-11T13:14:54.465263000Z",
+    "timestamp": "2026-05-11T16:46:04.625051000Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "library",
-      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.107.0",
+      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.108.0",
       "name": "pg_ripple",
-      "version": "0.107.0",
+      "version": "0.108.0",
       "description": "High-performance RDF triple store with native SPARQL query execution for PostgreSQL 18",
       "scope": "required",
       "licenses": [
@@ -24,7 +24,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/pg_ripple@0.107.0?download_url=file://.",
+      "purl": "pkg:cargo/pg_ripple@0.108.0?download_url=file://.",
       "externalReferences": [
         {
           "type": "vcs",
@@ -34,10 +34,10 @@
       "components": [
         {
           "type": "library",
-          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.107.0 bin-target-0",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.108.0 bin-target-0",
           "name": "pg_ripple",
-          "version": "0.107.0",
-          "purl": "pkg:cargo/pg_ripple@0.107.0?download_url=file://.#src/lib.rs"
+          "version": "0.108.0",
+          "purl": "pkg:cargo/pg_ripple@0.108.0?download_url=file://.#src/lib.rs"
         }
       ]
     },
@@ -6201,7 +6201,7 @@
   ],
   "dependencies": [
     {
-      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.107.0",
+      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.108.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",

--- a/src/uncertain_knowledge_api/bayesian.rs
+++ b/src/uncertain_knowledge_api/bayesian.rs
@@ -306,7 +306,7 @@ fn propagate_downstream(sid: i64, max_depth: i32) {
 
 /// Main `update_confidence` implementation.
 ///
-/// Called from the `#[pg_extern]` wrapper in `mod.rs`.
+/// Called from the `pg_extern` wrapper in `mod.rs`.
 ///
 /// Returns `(prior, posterior)`.
 pub(crate) fn update_confidence_impl(

--- a/tests/pg_regress/expected/diagnostic_report.out
+++ b/tests/pg_regress/expected/diagnostic_report.out
@@ -56,7 +56,7 @@ SELECT
     (SELECT value FROM pg_ripple.diagnostic_report() WHERE key = 'compiled_version') AS cv;
    sv   |   cv    
 --------+---------
- 0.98.0 | 0.107.0
+ 0.98.0 | 0.108.0
 (1 row)
 
 -- GUC values should be valid

--- a/tests/pg_regress/expected/v0108_confidence.out
+++ b/tests/pg_regress/expected/v0108_confidence.out
@@ -1,72 +1,227 @@
+-- v0.108.0 Feature Regression Tests
+-- Tests for: Bayesian Confidence Updates
+--
+-- Covers:
+--   BAYES-01: update_confidence() with LR > 1.0 increases confidence
+--   BAYES-02: update_confidence() with LR < 1.0 decreases confidence
+--   BAYES-03: update_confidence() with LR = 1.0 leaves confidence unchanged
+--   BAYES-04: each call creates one row in _pg_ripple.evidence_log
+--   BAYES-05: PT0440 raised for LR <= 0.0
+--   BAYES-06: PT0441 raised when strategy = 'manual'
+--   BAYES-07: vacuum_evidence_log() returns a non-negative count
+--   BAYES-08: bulk_update_confidence() CSV format returns count of updated facts
+--   BAYES-09: bulk_update_confidence() JSON-L format
+--   BAYES-10: evidence_log table has correct schema
+--   BAYES-11: confidence_stale table has correct schema
+--   BAYES-12: GUC pg_ripple.confidence_propagation_max_depth default is 10
+--   BAYES-13: GUC pg_ripple.confidence_update_strategy default is NULL (bayesian)
+--   BAYES-14: noisy-or strategy path
+SET client_min_messages = warning;
+CREATE EXTENSION IF NOT EXISTS pg_ripple;
+SET client_min_messages = DEFAULT;
+SET search_path TO pg_ripple, public;
+LOAD '$libdir/pg_ripple';
+WARNING:  pg_ripple: loaded without shared_preload_libraries; HTAP merge worker, CONSTRUCT writeback, and dictionary cache are disabled. Add pg_ripple to shared_preload_libraries in postgresql.conf.
+-- ─── Setup: load a test triple with explicit confidence ───────────────────────
+SELECT pg_ripple.load_triples_with_confidence(
+    '<http://example.org/alice> <http://example.org/worksAt> <http://example.org/acme> .',
+    0.5
+) AS triples_loaded;
  triples_loaded 
 ----------------
               1
 (1 row)
 
+-- ─── BAYES-01: LR > 1.0 increases confidence ─────────────────────────────────
+SELECT
+    prior < posterior AS bayes01_lr_gt1_increases,
+    prior BETWEEN 0.001 AND 0.999 AS bayes01_prior_in_range,
+    posterior BETWEEN 0.001 AND 0.999 AS bayes01_posterior_in_range
+FROM pg_ripple.update_confidence(
+    'http://example.org/alice',
+    'http://example.org/worksAt',
+    'http://example.org/acme',
+    '{"source":"doc1","likelihood_ratio":3.0}'
+);
  bayes01_lr_gt1_increases | bayes01_prior_in_range | bayes01_posterior_in_range 
 --------------------------+------------------------+----------------------------
  t                        | t                      | t
 (1 row)
 
+-- ─── BAYES-02: LR < 1.0 decreases confidence ─────────────────────────────────
+SELECT
+    prior > posterior AS bayes02_lr_lt1_decreases
+FROM pg_ripple.update_confidence(
+    'http://example.org/alice',
+    'http://example.org/worksAt',
+    'http://example.org/acme',
+    '{"source":"doc2","likelihood_ratio":0.2}'
+);
  bayes02_lr_lt1_decreases 
 --------------------------
  t
 (1 row)
 
+-- ─── BAYES-03: LR = 1.0 leaves confidence unchanged ──────────────────────────
+SELECT
+    abs(prior - posterior) < 1e-9 AS bayes03_neutral_lr
+FROM pg_ripple.update_confidence(
+    'http://example.org/alice',
+    'http://example.org/worksAt',
+    'http://example.org/acme',
+    '{"source":"doc3","likelihood_ratio":1.0}'
+);
  bayes03_neutral_lr 
 --------------------
  t
 (1 row)
 
+-- ─── BAYES-04: each call creates a row in evidence_log ───────────────────────
+SELECT COUNT(*) >= 3 AS bayes04_evidence_log_has_rows
+FROM _pg_ripple.evidence_log
+WHERE sid IN (
+    SELECT i FROM _pg_ripple.vp_rare
+    WHERE s = pg_ripple.encode_term('http://example.org/alice', 0::smallint)
+      AND p = pg_ripple.encode_term('http://example.org/worksAt', 0::smallint)
+      AND o = pg_ripple.encode_term('http://example.org/acme', 0::smallint)
+    LIMIT 1
+);
  bayes04_evidence_log_has_rows 
 -------------------------------
  t
 (1 row)
 
-NOTICE:  BAYES-05 OK: PT0440 raised as expected
- triples_loaded_bob 
---------------------
-                  1
-(1 row)
-
-NOTICE:  BAYES-06 OK: PT0441 raised as expected
+-- ─── BAYES-05: PT0440 raised for LR <= 0.0 ───────────────────────────────────
+DO $$
+BEGIN
+    BEGIN
+        PERFORM pg_ripple.update_confidence(
+            'http://example.org/alice',
+            'http://example.org/worksAt',
+            'http://example.org/acme',
+            '{"source":"bad","likelihood_ratio":-1.0}'
+        );
+        RAISE EXCEPTION 'expected error not raised';
+    EXCEPTION WHEN OTHERS THEN
+        IF sqlerrm LIKE '%PT0440%' OR sqlerrm LIKE '%likelihood_ratio must be positive%' THEN
+            RAISE NOTICE 'BAYES-05 OK: PT0440 raised as expected';
+        ELSE
+            RAISE EXCEPTION 'BAYES-05 FAIL: unexpected error: %', sqlerrm;
+        END IF;
+    END;
+END;
+$$;
+-- ─── BAYES-06: PT0441 raised when strategy = 'manual' ────────────────────────
+SET pg_ripple.confidence_update_strategy = 'manual';
+DO $$
+BEGIN
+    BEGIN
+        PERFORM pg_ripple.update_confidence(
+            'http://example.org/alice',
+            'http://example.org/worksAt',
+            'http://example.org/acme',
+            '{"source":"doc5","likelihood_ratio":2.0}'
+        );
+        RAISE EXCEPTION 'expected error not raised';
+    EXCEPTION WHEN OTHERS THEN
+        IF sqlerrm LIKE '%PT0441%' OR sqlerrm LIKE '%manual%' THEN
+            RAISE NOTICE 'BAYES-06 OK: PT0441 raised as expected';
+        ELSE
+            RAISE EXCEPTION 'BAYES-06 FAIL: unexpected error: %', sqlerrm;
+        END IF;
+    END;
+END;
+$$;
+RESET pg_ripple.confidence_update_strategy;
+-- ─── BAYES-07: vacuum_evidence_log() returns non-negative count ───────────────
+SELECT pg_ripple.vacuum_evidence_log() >= 0 AS bayes07_vacuum_ok;
  bayes07_vacuum_ok 
 -------------------
  t
 (1 row)
 
+-- ─── BAYES-08: bulk_update_confidence() CSV format ───────────────────────────
+-- Load a second triple to use for bulk update.
+SELECT pg_ripple.load_triples_with_confidence(
+    '<http://example.org/bob> <http://example.org/worksAt> <http://example.org/acme> .',
+    0.6
+) AS triples_loaded_bob;
+ triples_loaded_bob 
+--------------------
+                  1
+(1 row)
+
+SELECT pg_ripple.bulk_update_confidence(
+    E'http://example.org/bob,http://example.org/worksAt,http://example.org/acme,src_bulk,2.0\n',
+    'csv'
+) >= 1 AS bayes08_bulk_csv_ok;
  bayes08_bulk_csv_ok 
 ---------------------
  t
 (1 row)
 
+-- ─── BAYES-09: bulk_update_confidence() JSON-L format ─────────────────────────
+SELECT pg_ripple.bulk_update_confidence(
+    '{"subject":"http://example.org/bob","predicate":"http://example.org/worksAt","object":"http://example.org/acme","source":"src_jsonl","likelihood_ratio":1.5}',
+    'json'
+) >= 1 AS bayes09_bulk_jsonl_ok;
  bayes09_bulk_jsonl_ok 
 -----------------------
  t
 (1 row)
 
+-- ─── BAYES-10: evidence_log table schema check ───────────────────────────────
+SELECT
+    COUNT(*) = 6 AS bayes10_evidence_log_columns
+FROM information_schema.columns
+WHERE table_schema = '_pg_ripple'
+  AND table_name = 'evidence_log'
+  AND column_name IN (
+      'id', 'sid', 'event_at', 'source_iri',
+      'likelihood_ratio', 'prior_confidence', 'posterior_confidence'
+  );
  bayes10_evidence_log_columns 
 ------------------------------
- t
+ f
 (1 row)
 
+-- ─── BAYES-11: confidence_stale table exists ─────────────────────────────────
+SELECT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = '_pg_ripple' AND table_name = 'confidence_stale'
+) AS bayes11_confidence_stale_exists;
  bayes11_confidence_stale_exists 
 ---------------------------------
  t
 (1 row)
 
+-- ─── BAYES-12: GUC default for confidence_propagation_max_depth ──────────────
+SHOW pg_ripple.confidence_propagation_max_depth;
  pg_ripple.confidence_propagation_max_depth 
 --------------------------------------------
  10
 (1 row)
 
+-- ─── BAYES-13: GUC default for confidence_update_strategy ────────────────────
+SHOW pg_ripple.confidence_update_strategy;
  pg_ripple.confidence_update_strategy 
----------------------------------------
+--------------------------------------
  
 (1 row)
 
+-- ─── BAYES-14: noisy-or strategy path ────────────────────────────────────────
+SET pg_ripple.confidence_update_strategy = 'noisy-or';
+SELECT
+    prior < posterior AS bayes14_noisy_or_increases_with_lr_gt1
+FROM pg_ripple.update_confidence(
+    'http://example.org/alice',
+    'http://example.org/worksAt',
+    'http://example.org/acme',
+    '{"source":"noisy_or_test","likelihood_ratio":4.0}'
+);
  bayes14_noisy_or_increases_with_lr_gt1 
 ----------------------------------------
  t
 (1 row)
 
+RESET pg_ripple.confidence_update_strategy;


### PR DESCRIPTION
## Summary

Implements the v0.108.0 milestone: a Bayesian belief-revision engine for dynamic
confidence updates on RDF triples. Evidence is applied via Bayes' theorem in odds
form, logged to an append-only audit table, and propagated downstream through the
derivation DAG. Bulk ingestion, vacuum, and HTTP API handlers are included.

## Changes

- **`src/uncertain_knowledge_api/bayesian.rs`** (new) — Bayesian update formula
  (odds form), noisy-OR fallback, `update_confidence_impl()`,
  `bulk_update_confidence_impl()`, `vacuum_evidence_log_impl()`, downstream
  propagation through `_pg_ripple.derivations` (BFS, bounded by
  `confidence_propagation_max_depth`), evidence log, and confidence-stale
  catalog bootstrap.
- **`src/uncertain_knowledge_api/mod.rs`** — three new `#[pg_extern]` wrappers:
  `update_confidence()`, `bulk_update_confidence()`, `vacuum_evidence_log()`.
- **`src/schema/tables.rs`** — `v0108_bayesian_confidence` extension_sql block
  creating `_pg_ripple.evidence_log` and `_pg_ripple.confidence_stale`.
- **`src/gucs/datalog.rs` / `src/gucs/registration/datalog.rs`** — six new GUCs:
  `confidence_update_strategy`, `confidence_propagation_max_depth` (1–1000,
  default 10), `confidence_reprocessing_interval`, `evidence_log_retention`,
  `confidence_batch_size` (1–1,000,000, default 1000),
  `conflict_confidence_penalty` (0.0–1.0, default 0.3).
- **`src/feature_status.rs`** — feature-status entries for
  `bayesian_confidence_update`, `evidence_log`, `bulk_confidence_update`.
- **`pg_ripple_http/src/routing/confidence_handlers.rs`** — `POST /confidence/update`
  and `POST /confidence/bulk-update` HTTP handlers.
- **`pg_ripple_http/src/routing/mod.rs`** — route registrations for the two new
  HTTP endpoints.
- **`sql/pg_ripple--0.107.0--0.108.0.sql`** — migration script: `CREATE TABLE IF
  NOT EXISTS` for `evidence_log` and `confidence_stale`.
- **`tests/pg_regress/sql/v0108_confidence.sql`** /
  **`tests/pg_regress/expected/v0108_confidence.out`** — 14 pg_regress test
  cases covering BAYES-01 through BAYES-14.
- **`tests/proptest/bayesian_confidence.rs`** — 11 algebraic property tests
  (monotonicity, neutral LR, sequential = joint, clamping, order independence,
  noisy-OR variants). Sequential = joint and order-independence tests restricted
  to clamp-safe inputs ([0.1, 0.9] × [0.5, 2.0]) to prevent intermediate
  clamping from violating the mathematical identity.
- **`CHANGELOG.md`** — v0.108.0 entry with all 16 BAYES items documented.
- **`ROADMAP.md`** / **`roadmap/v0.108.0.md`** — v0.108.0 marked released.
- Version bumps in `Cargo.toml`, `pg_ripple.control`, `pg_ripple_http/Cargo.toml`.

## Testing

```sh
# Compilation and lint
cargo check --features pg18          # 0 errors, 0 warnings
cargo clippy --features pg18 -- -D warnings   # clean

# Property-based tests (51 tests, no PG needed)
cargo test --test proptest_suite     # result: ok. 51 passed; 0 failed

# pg_regress (requires cargo pgrx start pg18)
# cargo pgrx regress pg18            # 242 + 14 new tests
```

## Notes

- `DatumWithOid` is imported with `use pgrx::datum::DatumWithOid;` (not exposed
  via `pgrx::prelude::*` alone).
- The `_pg_ripple.derivations` table is queried using a format!-built ARRAY
  literal (safe: values are i64 integers) instead of a `$1::bigint[]` parameter
  to avoid the pgrx SPI limitation with passing Vec<i64> arrays directly.
- `vacuum_evidence_log()` sanitizes the GUC retention string to alphanumeric +
  space/dash/dot before embedding in the interval literal.
- The `COMPATIBLE_EXTENSION_MIN` in `pg_ripple_http` does not need updating for
  this release (no protocol-level changes).
