### PR TITLE
docs: implement documentation-2.md plan — guardrails, drift checks, style, GUC fixes

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,108 @@
+name: Docs validation
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'scripts/check_docs_links.py'
+      - 'scripts/check_docs_summary.py'
+      - 'scripts/check_guc_drift.py'
+      - 'scripts/check_http_routes.py'
+      - 'pg_ripple_http/src/routing/mod.rs'
+      - 'src/gucs/**'
+      - 'justfile'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/check_docs_links.py'
+      - 'scripts/check_docs_summary.py'
+      - 'scripts/check_guc_drift.py'
+      - 'scripts/check_http_routes.py'
+      - 'pg_ripple_http/src/routing/mod.rs'
+      - 'src/gucs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-links:
+    name: Check local Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Check docs links
+        run: python3 scripts/check_docs_links.py
+
+  docs-summary:
+    name: Check SUMMARY.md coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Check SUMMARY.md coverage
+        run: python3 scripts/check_docs_summary.py
+
+  docs-build:
+    name: Build mdBook (with admonish)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Install mdBook
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --directory=/usr/local/bin
+
+      - name: Install mdbook-admonish
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - name: Install admonish
+        run: cargo install mdbook-admonish --locked
+
+      - name: Sync mirrored files
+        run: |
+          cp CHANGELOG.md docs/src/reference/changelog.md
+          cp ROADMAP.md docs/src/reference/roadmap.md
+          cp RELEASE.md docs/src/reference/release-process.md
+          cp -r blog docs/src/blog
+
+      - name: Fix relative links in mirrored files
+        run: |
+          sed -i 's|](roadmap/|](https://github.com/trickle-labs/pg-ripple/blob/main/roadmap/|g' \
+            docs/src/reference/roadmap.md
+          sed -i 's|](plans/|](https://github.com/trickle-labs/pg-ripple/blob/main/plans/|g' \
+            docs/src/reference/roadmap.md
+          sed -i 's|](ROADMAP\.md)|](roadmap.md)|g' \
+            docs/src/reference/changelog.md
+          sed -i 's|](ROADMAP\.md)|](roadmap.md)|g' \
+            docs/src/reference/release-process.md
+          sed -i 's|](AGENTS\.md|](https://github.com/trickle-labs/pg-ripple/blob/main/AGENTS.md|g' \
+            docs/src/reference/release-process.md
+
+      - name: Build docs
+        run: mdbook build docs
+
+  guc-drift:
+    name: GUC drift check (report-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Check GUC drift
+        # Report-only: does not fail the build yet.
+        # Switch to --strict once the initial backlog in B1 is cleared.
+        run: python3 scripts/check_guc_drift.py
+
+  http-routes:
+    name: HTTP route drift check (report-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Check HTTP route drift
+        # Report-only: does not fail the build yet.
+        # Switch to --strict once the initial backlog in B2 is cleared.
+        run: python3 scripts/check_http_routes.py

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -69,6 +69,28 @@ Perform these steps in order.
 
    All five must pass with zero warnings and zero failures.
 
+2. **Documentation validation**
+
+   Run the full docs check before tagging:
+
+   ```bash
+   just docs-check
+   mdbook build docs
+   ```
+
+   Verify:
+   - `just docs-check-links` exits 0 (no broken local links).
+   - `just docs-check-summary` exits 0 (no orphan pages).
+   - `just docs-check-http-routes` lists no undocumented routes.
+   - `just docs-check-guc-drift` lists no missing GUCs with significant defaults.
+   - New HTTP routes added in this version appear in `docs/src/reference/http-api.md`.
+   - New GUCs added in this version appear in `docs/src/reference/guc-reference.md`
+     and `docs/gucs.md`.
+   - New public SQL functions appear in `docs/src/reference/sql-api.md` or are
+     explicitly marked as internal/admin.
+   - The migration script has upgrade docs if it changes user-visible schema.
+   - `CHANGELOG.md` links to any new user-facing docs pages.
+
 2. **Tag the release**
 
    Before tagging, verify the version bump and compatibility constant are correct:

--- a/docs/GAP_ANALYSIS.md
+++ b/docs/GAP_ANALYSIS.md
@@ -1,5 +1,9 @@
 # pg_ripple Documentation — Gap Analysis Report
 
+> **Status**: Historical audit. Superseded by [plans/documentation-2.md](../plans/documentation-2.md) on 2026-05-22.
+> Counts, version references, and critical issues below reflect the v0.99.1-era
+> documentation state and should not be treated as the current source of truth.
+
 > **Date**: 2026-05-11
 > **Scope**: Full audit of `docs/src/`, `blog/`, cross-referenced against `src/`, `CHANGELOG.md`, and `AGENTS.md`
 > **Current version**: v0.99.1 (approaching v1.0.0)

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -1,5 +1,9 @@
 # pg_ripple Documentation — Improvement Plan
 
+> **Status**: Historical plan. Superseded by [plans/documentation-2.md](../plans/documentation-2.md) on 2026-05-22.
+> The items below reflect the v0.99.1-era audit and are retained for context,
+> not as the current documentation backlog.
+
 > **Date**: 2026-05-11
 > **Input**: [GAP_ANALYSIS.md](GAP_ANALYSIS.md)
 > **Sequencing**: Critical → High → Medium → Low. Within each tier, items are ordered by impact and dependency.

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,171 @@
+# pg_ripple Documentation Style Guide
+
+> This guide applies to all pages under `docs/src/`. Generated reference pages
+> (GUC tables, SQL function lists, HTTP endpoint inventory) are exempt from
+> prose-style rules but must follow heading and code-fence conventions.
+
+## 1. Guiding Principles
+
+- **Current behaviour first.** Describe what is true now. Put version history in
+  a note or a "Since" line at the bottom of the section.
+- **Operational framing.** Write for a practitioner setting up or debugging a
+  deployment, not a researcher reading a design document.
+- **No false precision.** Do not claim exact throughput numbers unless a
+  benchmark file or CI result is linked.
+- **Short is good.** A reader who has to scroll past 200 lines of background
+  before reaching the first SQL example will give up.
+
+---
+
+## 2. Page Types and Responsibilities
+
+| Type | Purpose | Lives in |
+|---|---|---|
+| Feature page | Explains a concept and its primary workflow | `docs/src/features/` |
+| Reference page | Enumerates exact APIs, signatures, GUCs, limits, error codes | `docs/src/reference/` |
+| Guide / walkthrough | End-to-end task with prerequisites and decision points | `docs/src/guides/` |
+| Cookbook recipe | Solves exactly one concrete problem, minimal detours | `docs/src/cookbook/` |
+| Operations page | Deployment, failure modes, and operational tuning | `docs/src/operations/` |
+| Getting-started page | Short path to success for a first-time reader | `docs/src/getting-started/` |
+
+**Do not duplicate content across page types.** Instead, link between them.
+A cookbook recipe may reference a feature page for background but must not
+re-explain concepts at length.
+
+---
+
+## 3. Extension and Companion Names
+
+| Name | What it refers to | Not used for |
+|---|---|---|
+| `pg_ripple` | The PostgreSQL extension itself | The HTTP companion |
+| `pg_ripple_http` | The standalone HTTP/Flight companion service | The PG extension |
+| `pg_trickle` | IVM-backed views, ExtVP, SHACL DAG monitors, live statistics | Relay or CDC delivery |
+| `pg_tide` | Relay/outbox/inbox transport, CDC delivery bridge | IVM views |
+
+**Use `pg_trickle` only** when the code path explicitly requires
+`pg_ripple.trickle_integration = on` or calls into the pg_trickle extension.
+
+**Use `pg_tide` only** when the code path involves the outbox/inbox relay
+protocol or the `pg_tide_available()` function guard.
+
+---
+
+## 4. SQL Formatting
+
+- Use `` sql `` code fences for SQL examples.
+- Use `postgresql` fences only for PostgreSQL-dialect-specific content (e.g.
+  `EXPLAIN` output, `pg_dump` invocations).
+- Qualify function names with the schema on first mention:
+  `pg_ripple.sparql_select(...)`, not `sparql_select(...)`.
+- Use lowercase SQL keywords (`select`, `insert`, `where`, `from`) in examples
+  and uppercase only when quoting PostgreSQL documentation or explaining
+  parsing rules.
+- Mark examples that cannot run without external services:
+
+  ```sql
+  -- requires: pg_tide (relay), pg_trickle (IVM), pgvector, PostGIS
+  ```
+
+---
+
+## 5. Code-Block Labels
+
+Every code block should be one of:
+
+| Label | Meaning | How to mark |
+|---|---|---|
+| Executable | Runs against a fresh pg_ripple DB | No special annotation needed — assumed unless marked otherwise |
+| Illustrative | Conceptual; may use ellipsis or placeholder values | Comment `-- illustrative` as the first line |
+| Pseudo-output | Shows expected terminal or query output | Use a plain text or `text` fence |
+
+---
+
+## 6. Callouts
+
+Use mdbook-admonish syntax for callouts. Prefer these four:
+
+```
+> **Note**: short informational aside.
+```
+
+```admonish note
+Short informational aside.
+```
+
+```admonish warning
+Something the reader might do wrong.
+```
+
+```admonish tip
+Shortcut or best practice.
+```
+
+```admonish danger
+Data-loss or security risk.
+```
+
+Do not use `> **Warning:**` or `> **Note:**` raw blockquotes when
+`mdbook-admonish` is available (CI uses it; local builds degrade gracefully).
+
+---
+
+## 7. Headings and Structure
+
+- `#` is reserved for the page title only.
+- Use `##` for major sections and `###` for subsections.
+- Do not skip heading levels.
+- Keep heading text sentence-case: "SPARQL query execution" not "SPARQL Query Execution".
+
+---
+
+## 8. Links
+
+- Use relative links between pages in `docs/src/`.
+- Do not use relative paths from `docs/src/` to top-level `blog/` or `plans/`
+  directories — use absolute GitHub URLs instead:
+  `https://github.com/trickle-labs/pg-ripple/blob/main/blog/pagerank.md`
+- External links are checked only in scheduled CI, not on every PR.
+
+---
+
+## 9. Version References
+
+- For feature availability, use a short "Since v0.X.Y" note at the end of the
+  relevant section or in a front-matter-style table.
+- Do not write "as of v0.X.Y" in running prose — it dates quickly and is
+  confusing once a newer version is out.
+- When a feature was removed or replaced, state what replaced it.
+
+---
+
+## 10. Optional Dependencies
+
+Every page that describes a feature requiring an optional extension or service
+should include a front-matter-style dependency table at the top:
+
+```
+| Dependency | Required? | Notes |
+|---|---|---|
+| `pg_trickle` | Optional | IVM live-view updates only |
+| `pg_tide` | Optional | Relay/outbox delivery only |
+| `pgvector` | Optional | Vector hybrid search |
+| `PostGIS` | Optional | Geospatial SPARQL functions |
+| `pg_ripple_http` | Optional | REST/Arrow Flight access |
+| Citus | Optional | Horizontal sharding |
+```
+
+---
+
+## 11. PR Checklist
+
+When opening a docs PR, verify:
+
+- [ ] `python3 scripts/check_docs_links.py` exits 0.
+- [ ] `python3 scripts/check_docs_summary.py` exits 0.
+- [ ] `mdbook build docs` succeeds.
+- [ ] New routes are in `docs/src/reference/http-api.md`.
+- [ ] New GUCs are in `docs/src/reference/guc-reference.md` and `docs/gucs.md`.
+- [ ] New SQL functions are in the SQL reference or explicitly marked internal.
+- [ ] Optional-dependency tables are present on feature pages that require them.
+- [ ] Code examples follow section 5 labelling conventions.

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,6 +9,7 @@ build-dir = "book"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
+optional = true
 assets_version = "3.0.2"
 
 [output.html]

--- a/docs/gucs.md
+++ b/docs/gucs.md
@@ -32,21 +32,21 @@
 | GUC | Type | Default | Context | Description |
 |-----|------|---------|---------|-------------|
 | `vp_promotion_threshold` | integer | 1000 | Suset | Minimum triple count before a rare-predicate is promoted to its own VP table |
-| `vp_promotion_batch_size` | integer | 500 | Suset | Batch size for bulk VP promotion |
-| `columnar_threshold` | integer | 100000 | Suset | Row count above which main partitions use columnar storage |
-| `adaptive_indexing_enabled` | bool | on | Suset | Allow the merge worker to create secondary indexes dynamically |
-| `dedup_on_merge` | bool | on | Suset | Deduplicate triples during HTAP merge |
+| `vp_promotion_batch_size` | integer | 10000 | Suset | Batch size for bulk VP promotion |
+| `columnar_threshold` | integer | -1 | Suset | Row count above which main partitions use columnar storage (-1 = disabled) |
+| `adaptive_indexing_enabled` | bool | off | Suset | Allow the merge worker to create secondary indexes dynamically |
+| `dedup_on_merge` | bool | off | Suset | Deduplicate triples during HTAP merge |
 | `tombstone_gc_enabled` | bool | on | Suset | Enable background GC of tombstone rows |
 | `tombstone_gc_threshold` | integer | 10000 | Suset | Number of tombstones that trigger a GC cycle |
-| `tombstone_retention_seconds` | integer | 3600 | Suset | Seconds to retain tombstones before GC eligibility |
+| `tombstone_retention_seconds` | integer | 0 | Suset | Seconds to retain tombstones before GC eligibility (0 = immediate) |
 | `delta_index_threshold` | integer | 5000 | Suset | Delta-partition row count triggering automatic index creation |
-| `dict_vacuum_threshold` | integer | 50000 | Suset | Dictionary table dead-tuple threshold before auto-vacuum |
-| `vacuum_dict_batch_size` | integer | 1000 | Suset | Batch size for incremental dictionary vacuum |
+| `dict_vacuum_threshold` | integer | 10000 | Suset | Dictionary table dead-tuple threshold before auto-vacuum |
+| `vacuum_dict_batch_size` | integer | 200 | Suset | Batch size for incremental dictionary vacuum |
 | `auto_analyze` | bool | on | Suset | Enable automatic ANALYZE on VP tables after merge |
 | `stats_refresh_interval_seconds` | integer | 300 | Suset | Seconds between background stats-refresh cycles |
-| `stats_scan_limit` | integer | 10000 | Suset | Maximum rows sampled per VP table during stats refresh |
+| `stats_scan_limit` | integer | 1000 | Suset | Maximum rows sampled per VP table during stats refresh |
 | `bulk_load_use_copy` | bool | on | Suset | Use COPY instead of INSERT for bulk RDF loads |
-| `export_batch_size` | integer | 1000 | Userset | Rows per batch when serializing RDF exports |
+| `export_batch_size` | integer | 10000 | Userset | Rows per batch when serializing RDF exports |
 | `export_max_rows` | integer | 1000000 | Userset | Hard cap on rows returned by export functions |
 | `export_confidence` | real | 0.0 | Userset | Minimum confidence score for triples included in exports |
 
@@ -86,7 +86,7 @@
 | `approx_distinct` | bool | off | Userset | Use HyperLogLog approximation for `COUNT(DISTINCT ...)` |
 | `describe_strategy` | string | `'cbd'` | Userset | DESCRIBE form: `'cbd'` (concise bounded description) or `'symcbd'` |
 | `describe_form` | string | `'turtle'` | Userset | Serialization format for DESCRIBE responses |
-| `describe_max_depth` | integer | 3 | Userset | Maximum hop depth for symmetric CBD DESCRIBE |
+| `describe_max_depth` | integer | 16 | Userset | Maximum hop depth for symmetric CBD DESCRIBE |
 | `default_graph` | string | `''` | Userset | Named graph IRI used when no GRAPH clause is specified (empty = default graph) |
 | `use_graph_context` | bool | on | Userset | Include graph column in SPARQL result bindings |
 
@@ -189,21 +189,21 @@
 | GUC | Type | Default | Context | Description |
 |-----|------|---------|---------|-------------|
 | `cdc_bridge_enabled` | bool | off | Suset | Enable the CDC outbox bridge for downstream consumers |
-| `cdc_bridge_batch_size` | integer | 500 | Suset | Triples per batch written to the CDC outbox table |
-| `cdc_bridge_flush_ms` | integer | 100 | Suset | Maximum milliseconds between CDC outbox flushes |
+| `cdc_bridge_batch_size` | integer | 100 | Suset | CDC notifications batched before a pg_tide outbox flush |
+| `cdc_bridge_flush_ms` | integer | 200 | Suset | Maximum milliseconds between CDC outbox flushes |
 | `cdc_bridge_outbox_table` | string | `''` | Suset | Fully-qualified name of the CDC outbox table |
-| `cdc_slot_idle_timeout_seconds` | integer | 30 | Suset | Idle timeout (s) for logical-replication slot workers |
-| `cdc_watermark_batch_size` | integer | 1000 | Suset | CDC watermark rows processed per cycle |
-| `cdc_watermark_flush_interval_ms` | integer | 500 | Suset | Watermark flush interval (ms) |
-| `temporal_cdc_enabled` | bool | off | Suset | Enable CDC support for temporal (valid-time) triple versions |
+| `cdc_slot_idle_timeout_seconds` | integer | 3600 | Suset | Idle timeout (s) before orphaned CDC slots are dropped |
+| `cdc_watermark_batch_size` | integer | 100 | Suset | CDC watermark rows processed per cycle |
+| `cdc_watermark_flush_interval_ms` | integer | 50 | Suset | Watermark flush interval (ms) |
+| `temporal_cdc_enabled` | bool | on | Suset | Enable CDC support for temporal (valid-time) triple versions |
 | `temporal_data_model` | string | `'point'` | Suset | Temporal data model: `'point'` or `'interval'` |
 | `enable_temporal_operators` | bool | off | Userset | Enable temporal SPARQL extensions (`VALID_TIME`, `AS OF`) |
 | `replication_enabled` | bool | off | Suset | Enable built-in logical replication between pg_ripple instances |
-| `replication_batch_size` | integer | 500 | Suset | Triples per logical-replication batch |
-| `replication_batch_interval_ms` | integer | 200 | Suset | Interval (ms) between replication batch flushes |
-| `replication_conflict_strategy` | string | `'last-write-wins'` | Suset | Replication conflict resolution: `'last-write-wins'` or `'source-wins'` |
+| `replication_batch_size` | integer | 100 | Suset | Triples per logical-replication batch |
+| `replication_batch_interval_ms` | integer | 500 | Suset | Interval (ms) between replication batch flushes |
+| `replication_conflict_strategy` | string | `'last_writer_wins'` | Suset | Logical apply conflict strategy; current worker uses `'last_writer_wins'` |
 | `read_replica_dsn` | string | `''` | Suset | Connection string for directing read-only queries to a replica |
-| `trickle_integration` | bool | off | Suset | Enable integration with pg-trickle CDC subscriptions |
+| `trickle_integration` | bool | on | Userset | Legacy relay integration switch; disables the pg_tide CDC bridge when set to `off` |
 
 ---
 
@@ -267,7 +267,7 @@
 | `pagerank_selective_threshold` | real | 0.01 | Userset | Minimum personalization weight for selective PageRank |
 | `pagerank_temp_threshold` | integer | 50000 | Suset | Row count above which PageRank uses temporary tables |
 | `pagerank_shacl_threshold` | real | 0.5 | Userset | Minimum PageRank score for SHACL-constrained node filtering |
-| `pagerank_trickle_confidence_attenuation` | real | 0.9 | Suset | Confidence attenuation factor for pg-trickle–based PageRank IVM |
+| `pagerank_trickle_confidence_attenuation` | bool | on | Userset | Attenuate incremental K-hop PageRank deltas by edge confidence |
 | `pagerank_sketch_width` | integer | 2048 | Suset | Width of the Count-Min sketch for approximate PageRank |
 | `pagerank_sketch_depth` | integer | 5 | Suset | Depth of the Count-Min sketch for approximate PageRank |
 
@@ -302,7 +302,7 @@
 
 | GUC | Type | Default | Context | Description |
 |-----|------|---------|---------|-------------|
-| `arrow_batch_size` | integer | 65536 | Suset | Rows per Arrow record batch in bulk export |
+| `arrow_batch_size` | integer | 1000 | Userset | Rows per Arrow record batch in bulk export |
 | `arrow_flight_secret` | string | `''` | Suset | HMAC secret used to sign Arrow Flight session tickets |
 | `arrow_flight_expiry_secs` | integer | 3600 | Suset | Expiry time (s) for Arrow Flight session tickets |
 | `arrow_unsigned_tickets_allowed` | bool | off | Suset | Accept Arrow Flight tickets without an HMAC signature (testing only) |
@@ -314,9 +314,9 @@
 | GUC | Type | Default | Context | Description |
 |-----|------|---------|---------|-------------|
 | `citus_sharding_enabled` | bool | off | Suset | Enable Citus distributed sharding for VP tables |
-| `citus_service_pruning` | bool | on | Suset | Enable predicate-level shard pruning for SERVICE queries |
-| `citus_prune_carry_max` | integer | 64 | Suset | Maximum number of shard bindings carried across joins during pruning |
-| `citus_trickle_compat` | bool | off | Suset | Enable pg-trickle compatibility mode for Citus CDC |
+| `citus_service_pruning` | bool | off | Suset | Enable predicate-level shard pruning for SERVICE queries |
+| `citus_prune_carry_max` | integer | 1000 | Userset | Maximum number of shard bindings carried across joins during pruning |
+| `citus_trickle_compat` | bool | off | Userset | Legacy compatibility mode using `colocate_with => 'none'` for Citus CDC/IVM integrations |
 
 ---
 

--- a/docs/src/cookbook/rule-federation.md
+++ b/docs/src/cookbook/rule-federation.md
@@ -1,77 +1,59 @@
-# Rule-Library Federation
+# Rule-Library Federation Recipe
 
 > Added in v0.120.0
 
-Rule-Library Federation lets you publish a named Datalog/SPARQL rule set from one
-pg_ripple instance and subscribe to it from another — enabling a rule-library
-marketplace pattern across a fleet of pg_ripple deployments.
+Use this recipe when you already have a versioned rule library and want to share
+it across pg_ripple instances. For the full walkthrough, including a two-instance
+setup and monitoring examples, see the [Rule Library Federation guide](../guides/rule-library-federation.md).
 
-## Publishing a Rule Library
+## When to Use This
 
-On the source instance, mark a named rule library as publicly accessible:
+Rule-library federation fits teams that maintain shared Datalog or SHACL rule
+sets, such as RDFS entailment, customer deduplication, or compliance checks, and
+need the same rules installed consistently across environments.
+
+## Minimal Flow
+
+1. Install or create the library on the source instance.
+2. Publish the library with the URL where the HTTP companion serves its stream.
+3. Record a subscription on the target instance.
+4. Ask the target HTTP companion to fetch and install the remote stream.
 
 ```sql
+-- Source instance: publish an installed library.
 SELECT pg_ripple.publish_rule_library(
-  'my-owl-rl-rules',
-  'https://ripple-hub.example.com'
+  'rdfs-entailment',
+  'https://instance-a.example.com/rule-libraries/rdfs-entailment/stream'
 );
-```
 
-This records the library in `_pg_ripple.rule_library_federation` and makes it
-available via the HTTP companion's streaming endpoint.
-
-## Streaming Rules via HTTP
-
-Any client can fetch all rules from a published library as NDJSON:
-
-```bash
-curl https://ripple-hub.example.com/rule-libraries/my-owl-rl-rules/stream \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-Each line in the response is a JSON object:
-
-```json
-{"name":"my-owl-rl-rules","rule":"rdfs:subClassOf rule body...","version":"0.120.0"}
-```
-
-## Subscribing from Another Instance
-
-On the target instance, subscribe to a remote rule library:
-
-```sql
+-- Target instance: record subscription intent.
 SELECT pg_ripple.subscribe_rule_library(
-  'https://ripple-hub.example.com',
-  'my-owl-rl-rules'
+  'https://instance-a.example.com/rule-libraries/rdfs-entailment/stream',
+  'rdfs-entailment'
 );
 ```
 
-This records the subscription intent. The HTTP companion can then fetch rules:
-
 ```bash
-curl -X POST https://my-instance.example.com/rule-libraries/my-owl-rl-rules/subscribe \
-  -H "Authorization: Bearer $TOKEN" \
+# Target HTTP companion: fetch and install the stream.
+curl -X POST https://instance-b.example.com/rule-libraries/rdfs-entailment/subscribe \
+  -H "Authorization: Bearer $PG_RIPPLE_HTTP_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"source_uri": "https://ripple-hub.example.com/rule-libraries/my-owl-rl-rules/stream"}'
+  -d '{"source_uri":"https://instance-a.example.com/rule-libraries/rdfs-entailment/stream"}'
 ```
 
-## Security
+## Notes
 
-- Publishing requires `check_auth_write` (HTTP write token).
-- Subscribing also requires `check_auth_write`.
-- The source library endpoint validates authentication via the standard Bearer
-  token mechanism.
-- HTTPS is strongly recommended for all federation endpoints.
+- `publish_rule_library()` and `subscribe_rule_library()` are catalog operations;
+  they do not start a background daemon.
+- `POST /rule-libraries/{name}/subscribe` performs the remote fetch and installs
+  rules into the target instance.
+- The current HTTP fetcher does not forward a separate Authorization header to
+  the source stream. For protected source streams, use a trusted internal route
+  or fetch from an authenticated client.
 
-## Environment Variables
+## See Also
 
-| Variable | Description |
-|----------|-------------|
-| `PG_RIPPLE_HTTP_AUTH_TOKEN` | Bearer token for authenticating requests |
-| `PG_RIPPLE_HTTP_URL` | Base URL of the HTTP companion |
-
-## Monitoring
-
-The `GET /admin/diagnostic-snapshot` endpoint includes `rule_library_federation`
-table row counts, making it easy to audit which libraries are published or
-subscribed on each instance.
+- [Rule Library Federation guide](../guides/rule-library-federation.md)
+- [SQL API: publish_rule_library](../reference/sql-api.md#publish_rule_library)
+- [SQL API: subscribe_rule_library](../reference/sql-api.md#subscribe_rule_library)
+- [HTTP API reference](../reference/http-api.md#complete-endpoint-reference)

--- a/docs/src/cookbook/rule-libraries.md
+++ b/docs/src/cookbook/rule-libraries.md
@@ -1,7 +1,7 @@
 # Rule Libraries
 
 > **Version**: v0.104.0  
-> **Foundation**: [plans/expert-system.md §5](../../plans/expert-system.md)
+> **Foundation**: [plans/expert-system.md §5](https://github.com/trickle-labs/pg-ripple/blob/main/plans/expert-system.md)
 
 A **rule library** is a versioned, distributable package of Datalog inference rules
 and SHACL validation shapes. Libraries allow teams to share domain-specific

--- a/docs/src/cookbook/skos-thesaurus.md
+++ b/docs/src/cookbook/skos-thesaurus.md
@@ -194,5 +194,5 @@ SELECT * FROM pg_ripple.active_datalog_bundles;
 ## See Also
 
 - [SKOS Reference](https://www.w3.org/TR/skos-reference/) — W3C Recommendation
-- [Datalog Built-in Rules](../reference/datalog-built-in-rules.md) — full rule catalogue
+- [Datalog Reference](../reference/datalog.md) — built-in RDFS and OWL RL rule support
 - [SQL Functions Reference](../reference/sql-functions.md) — all pg_ripple SQL functions

--- a/docs/src/features/advanced-inference.md
+++ b/docs/src/features/advanced-inference.md
@@ -138,6 +138,6 @@ None of them requires configuration. They are part of the engine's normal operat
 
 ## Further reading
 
-- [Blog: Leapfrog Triejoin](../../blog/leapfrog-triejoin.md) — how worst-case optimal joins accelerate cyclic patterns
-- [Blog: Well-Founded Semantics](../../blog/well-founded-semantics.md) — three-valued logic for cyclic rules
-- [Blog: Magic Sets for Goal-Directed Inference](../../blog/magic-sets-goal-directed.md) — demand-driven evaluation
+- [Blog: Leapfrog Triejoin](https://github.com/trickle-labs/pg-ripple/blob/main/blog/leapfrog-triejoin.md) — how worst-case optimal joins accelerate cyclic patterns
+- [Blog: Well-Founded Semantics](https://github.com/trickle-labs/pg-ripple/blob/main/blog/well-founded-semantics.md) — three-valued logic for cyclic rules
+- [Blog: Magic Sets for Goal-Directed Inference](https://github.com/trickle-labs/pg-ripple/blob/main/blog/magic-sets-goal-directed.md) — demand-driven evaluation

--- a/docs/src/features/cdc-subscriptions.md
+++ b/docs/src/features/cdc-subscriptions.md
@@ -170,4 +170,4 @@ ws.onmessage = (event) => {
 
 ## Further reading
 
-- [Blog: CDC and Knowledge Graphs](../../blog/cdc-knowledge-graphs.md) — real-time event streaming from your knowledge graph
+- [Blog: CDC and Knowledge Graphs](https://github.com/trickle-labs/pg-ripple/blob/main/blog/cdc-knowledge-graphs.md) — real-time event streaming from your knowledge graph

--- a/docs/src/features/exporting-and-sharing.md
+++ b/docs/src/features/exporting-and-sharing.md
@@ -590,4 +590,4 @@ may use significant memory. Switch to streaming variants or `COPY ... TO` with s
 
 ## Further reading
 
-- [Blog: JSON-LD Framing for Nested JSON](../../blog/json-ld-framing-nested-json.md) — shaping graph data into API-ready JSON documents
+- [Blog: JSON-LD Framing for Nested JSON](https://github.com/trickle-labs/pg-ripple/blob/main/blog/json-ld-framing-nested-json.md) — shaping graph data into API-ready JSON documents

--- a/docs/src/features/geospatial.md
+++ b/docs/src/features/geospatial.md
@@ -108,4 +108,4 @@ If you need any of these, file an issue — most are a thin wrapper over the cor
 
 ## Further reading
 
-- [Blog: GeoSPARQL + PostGIS Spatial Queries](../../blog/geosparql-postgis-spatial.md) — combining geographic and semantic queries
+- [Blog: GeoSPARQL + PostGIS Spatial Queries](https://github.com/trickle-labs/pg-ripple/blob/main/blog/geosparql-postgis-spatial.md) — combining geographic and semantic queries

--- a/docs/src/features/graphrag.md
+++ b/docs/src/features/graphrag.md
@@ -231,4 +231,4 @@ Pass `''` for the default graph or a named-graph IRI to scope the export.
 
 ## Further reading
 
-- [Blog: GraphRAG Knowledge Export](../../blog/graphrag-knowledge-export.md) — building a Microsoft GraphRAG pipeline with pg_ripple
+- [Blog: GraphRAG Knowledge Export](https://github.com/trickle-labs/pg-ripple/blob/main/blog/graphrag-knowledge-export.md) — building a Microsoft GraphRAG pipeline with pg_ripple

--- a/docs/src/features/json-mapping.md
+++ b/docs/src/features/json-mapping.md
@@ -100,6 +100,43 @@ SELECT * FROM pg_ripple.json_writeback_status();
 --  mapping_name | pending | errors | last_error | last_processed_at
 ```
 
+### HTTP Writeback
+
+The HTTP companion exposes the same writeback path for applications that do not
+call SQL directly:
+
+```bash
+curl -X POST http://localhost:7878/json-mapping/contacts/writeback \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"subject_iri":"https://example.com/contacts/c001"}'
+```
+
+Successful synchronous writeback returns:
+
+```json
+{"rows_affected": 1}
+```
+
+Queue status for one mapping is available over HTTP as well:
+
+```bash
+curl http://localhost:7878/json-mapping/contacts/writeback/status \
+    -H "Authorization: Bearer $TOKEN"
+```
+
+The status response mirrors `json_writeback_status()` for the selected mapping:
+
+```json
+{
+    "mapping_name": "contacts",
+    "pending": 0,
+    "errors": 0,
+    "last_error": null,
+    "last_processed_at": null
+}
+```
+
 Disable triggers:
 
 ```sql
@@ -117,6 +154,7 @@ Both `enable_json_writeback()` and `disable_json_writeback()` are idempotent.
 
 ## See Also
 
-- [JSON-LD Reverse Mapping blog post](../../blog/json-ld-reverse-mapping.md)
+- [JSON-LD Reverse Mapping blog post](https://github.com/trickle-labs/pg-ripple/blob/main/blog/json-ld-reverse-mapping.md)
 - [GUC reference: json_writeback_batch_size](../reference/guc-reference.md#pg_ripplejson_writeback_batch_size)
-- [R2RML for complex ETL](../reference/r2rml.md)
+- [HTTP API Reference](../reference/http-api.md#json-mapping-writeback)
+- [R2RML for complex ETL](r2rml.md)

--- a/docs/src/features/live-views-and-subscriptions.md
+++ b/docs/src/features/live-views-and-subscriptions.md
@@ -164,5 +164,5 @@ The two compose: build a view of *what is currently true*, and a subscription of
 
 ## Further reading
 
-- [Blog: CONSTRUCT Views — Live Transformations](../../blog/construct-views-live-transformations.md) — incremental materialization of SPARQL views
-- [Blog: IVM with pg-trickle Integration](../../blog/ivm-pg-trickle-integration.md) — how pg_ripple keeps views up to date
+- [Blog: CONSTRUCT Views — Live Transformations](https://github.com/trickle-labs/pg-ripple/blob/main/blog/construct-views-live-transformations.md) — incremental materialization of SPARQL views
+- [Blog: IVM with pg-trickle Integration](https://github.com/trickle-labs/pg-ripple/blob/main/blog/ivm-pg-trickle-integration.md) — how pg_ripple keeps views up to date

--- a/docs/src/features/multi-tenant-graphs.md
+++ b/docs/src/features/multi-tenant-graphs.md
@@ -162,4 +162,4 @@ TO '/tmp/acme.nq';
 
 ## Further reading
 
-- [Blog: Multi-Tenant Knowledge Graphs](../../blog/multi-tenant-knowledge-graphs.md) — isolation, quotas, and RLS patterns for SaaS deployments
+- [Blog: Multi-Tenant Knowledge Graphs](https://github.com/trickle-labs/pg-ripple/blob/main/blog/multi-tenant-knowledge-graphs.md) — isolation, quotas, and RLS patterns for SaaS deployments

--- a/docs/src/features/nl-to-sparql.md
+++ b/docs/src/features/nl-to-sparql.md
@@ -137,4 +137,4 @@ $$;
 
 ## Further reading
 
-- [Blog: Natural Language to SPARQL](../../blog/natural-language-to-sparql.md) — how pg_ripple translates plain-English questions into SPARQL queries
+- [Blog: Natural Language to SPARQL](https://github.com/trickle-labs/pg-ripple/blob/main/blog/natural-language-to-sparql.md) — how pg_ripple translates plain-English questions into SPARQL queries

--- a/docs/src/features/pagerank.md
+++ b/docs/src/features/pagerank.md
@@ -270,7 +270,7 @@ into a canonical representative before computing PageRank. This deduplication en
 edges to equivalent entities are not double-counted, which would otherwise inflate the
 PageRank score of heavily `sameAs`-clustered nodes.
 
-See [owl:sameAs Entity Resolution](../features/datalog.md) for canonicalization details.
+See [Reasoning and Inference](reasoning-and-inference.md) for canonicalization details.
 
 ## Portability Note (STD-04, v0.92.0)
 
@@ -291,4 +291,4 @@ WHERE feature LIKE 'pagerank%' OR feature LIKE 'centrality%';
 
 ## Further reading
 
-- [Blog: PageRank in pg_ripple](../../blog/pagerank.md) — Datalog-native PageRank with IVM and Prometheus integration
+- [Blog: PageRank in pg_ripple](https://github.com/trickle-labs/pg-ripple/blob/main/blog/pagerank.md) — Datalog-native PageRank with IVM and Prometheus integration

--- a/docs/src/features/querying-with-sparql.md
+++ b/docs/src/features/querying-with-sparql.md
@@ -749,6 +749,6 @@ graph modifications. Use `delete_triple()` for programmatic single-triple deleti
 
 ## Further reading
 
-- [Blog: SPARQL-to-SQL Translation](../../blog/sparql-to-sql-translation.md) — how pg_ripple compiles SPARQL into optimized PostgreSQL SQL
-- [Blog: Property Paths and Recursive CTEs](../../blog/property-paths-recursive-ctes.md) — the implementation of `*` and `+` path operators
-- [Blog: Explain SPARQL Query Plans](../../blog/explain-sparql-query-plans.md) — understanding the SPARQL query debugger
+- [Blog: SPARQL-to-SQL Translation](https://github.com/trickle-labs/pg-ripple/blob/main/blog/sparql-to-sql-translation.md) — how pg_ripple compiles SPARQL into optimized PostgreSQL SQL
+- [Blog: Property Paths and Recursive CTEs](https://github.com/trickle-labs/pg-ripple/blob/main/blog/property-paths-recursive-ctes.md) — the implementation of `*` and `+` path operators
+- [Blog: Explain SPARQL Query Plans](https://github.com/trickle-labs/pg-ripple/blob/main/blog/explain-sparql-query-plans.md) — understanding the SPARQL query debugger

--- a/docs/src/features/r2rml.md
+++ b/docs/src/features/r2rml.md
@@ -185,4 +185,4 @@ SELECT pg_ripple.shacl_validate();
 
 ## Further reading
 
-- [Blog: R2RML — Relational to Graph](../../blog/r2rml-relational-to-graph.md) — mapping existing PostgreSQL tables to RDF
+- [Blog: R2RML — Relational to Graph](https://github.com/trickle-labs/pg-ripple/blob/main/blog/r2rml-relational-to-graph.md) — mapping existing PostgreSQL tables to RDF

--- a/docs/src/features/reasoning-and-inference.md
+++ b/docs/src/features/reasoning-and-inference.md
@@ -533,7 +533,7 @@ SELECT * FROM pg_ripple.rule_plan_cache_stats();
 
 ## Further reading
 
-- [Blog: Datalog Inside PostgreSQL](../../blog/datalog-inside-postgresql.md) — how the Datalog engine works under the hood
-- [Blog: Built-in Reasoning Rules Explained](../../blog/builtin-reasoning-rules-explained.md) — the RDFS and OWL RL rule sets
-- [Blog: Magic Sets for Goal-Directed Inference](../../blog/magic-sets-goal-directed.md) — how demand-driven evaluation speeds up queries
-- [Blog: Well-Founded Semantics](../../blog/well-founded-semantics.md) — handling negation in cyclic rules
+- [Blog: Datalog Inside PostgreSQL](https://github.com/trickle-labs/pg-ripple/blob/main/blog/datalog-inside-postgresql.md) — how the Datalog engine works under the hood
+- [Blog: Built-in Reasoning Rules Explained](https://github.com/trickle-labs/pg-ripple/blob/main/blog/builtin-reasoning-rules-explained.md) — the RDFS and OWL RL rule sets
+- [Blog: Magic Sets for Goal-Directed Inference](https://github.com/trickle-labs/pg-ripple/blob/main/blog/magic-sets-goal-directed.md) — how demand-driven evaluation speeds up queries
+- [Blog: Well-Founded Semantics](https://github.com/trickle-labs/pg-ripple/blob/main/blog/well-founded-semantics.md) — handling negation in cyclic rules

--- a/docs/src/features/record-linkage.md
+++ b/docs/src/features/record-linkage.md
@@ -226,5 +226,5 @@ Most record-linkage systems force a choice between *neural* (high-recall, opaque
 
 ## Further reading
 
-- [Blog: Neuro-Symbolic Entity Resolution](../../blog/neuro-symbolic-entity-resolution.md) — combining embeddings with symbolic rules for deduplication
-- [Blog: owl:sameAs Entity Resolution](../../blog/owl-sameas-entity-resolution.md) — how equivalence canonicalization works
+- [Blog: Neuro-Symbolic Entity Resolution](https://github.com/trickle-labs/pg-ripple/blob/main/blog/neuro-symbolic-entity-resolution.md) — combining embeddings with symbolic rules for deduplication
+- [Blog: owl:sameAs Entity Resolution](https://github.com/trickle-labs/pg-ripple/blob/main/blog/owl-sameas-entity-resolution.md) — how equivalence canonicalization works

--- a/docs/src/features/shacl-sparql-rules.md
+++ b/docs/src/features/shacl-sparql-rules.md
@@ -2,8 +2,7 @@
 
 Stock SHACL Core covers ~95 % of the constraints anyone needs in practice — cardinalities, datatypes, value ranges, property paths. The other 5 % is where SHACL Core runs out of expressiveness: cross-shape conditions, complex logical compositions, "this attribute must equal the sum of those attributes", and so on. **SHACL-SPARQL** ([Advanced Features](https://www.w3.org/TR/shacl-af/)) closes the gap by letting you embed a SPARQL query inside a shape.
 
-pg_ripple supports `sh:SPARQLConstraint` (validation) and `sh:TripleRule` (inference).
-`sh:SPARQLRule` (SPARQL-based inference) is **not yet supported** — see the note below.
+pg_ripple supports `sh:SPARQLConstraint` (validation), `sh:TripleRule` (inference), and `sh:SPARQLRule` (SPARQL CONSTRUCT-based inference, added in v0.79.0).
 
 ---
 
@@ -65,94 +64,6 @@ SELECT pg_ripple.shacl_apply_rules();
 ```
 
 Triples produced by `sh:TripleRule` are written with `source = 1` (inferred) — they coexist with explicit triples but stay distinguishable.
-
----
-
-## `sh:SPARQLRule` — not yet supported
-
-`sh:SPARQLRule` (SPARQL CONSTRUCT-based inference) is **not implemented** in v0.70.0.
-
-When pg_ripple encounters a `sh:SPARQLRule` in a loaded SHACL document, it emits a PostgreSQL `WARNING` (error code PT481) and skips the rule without error. No inference is performed.
-
-```
-WARNING:  PT481: sh:SPARQLRule is not supported in this version; rule skipped
-```
-
-Full `sh:SPARQLRule` support is planned for v1.0.0. In the meantime, the equivalent inference can be expressed using the Datalog engine or a SPARQL CONSTRUCT writeback rule:
-
-```sql
--- Alternative: Datalog rule (same semantics as an sh:SPARQLRule)
-SELECT pg_ripple.add_rule(
-    'adult(?person)',
-    'type(?person, schema:Person), age(?person, ?a), ?a >= 18'
-);
-```
-
----
-
-## When to use SHACL-SPARQL vs Datalog
-
-Both can express custom validation and inference. Pick by audience:
-
-| Concern | SHACL-SPARQL | Datalog |
-|---|---|---|
-| **Audience** | Data architects who already write SHACL | Engineers comfortable with logic programming |
-| **Tooling** | Standard SHACL editors and validators | pg_ripple-specific `.pl`-style files |
-| **Expressiveness** | Full SPARQL inside the shape | Recursion, magic sets, lattices, well-founded semantics |
-| **Performance** | Each query runs once per focus node | Compiled to a single SQL `INSERT … SELECT` per stratum |
-| **Recursion** | Limited — you can recurse manually with property paths | First-class — semi-naive evaluation, fixpoint |
-| **Negation** | SPARQL `FILTER NOT EXISTS` | Stratified negation; well-founded semantics |
-
-Rule of thumb: if the rule fits in one SHACL `sh:TripleRule`, write it in SHACL. If it is naturally recursive or needs negation, use Datalog.
-
----
-
-## Performance notes
-
-- `sh:SPARQLConstraint` is evaluated per focus node. For shapes whose target matches millions of nodes, pre-filter the target with a tighter `sh:targetClass` or `sh:targetSubjectsOf`.
-- `sh:TripleRule` is reapplied on every `shacl_apply_rules()` call. It is *not* incremental. For incremental inference, use the Datalog engine.
-- Both run in a single transaction; either everything succeeds or nothing changes.
-
----
-
-## See also
-
-- [Validating Data Quality](validating-data-quality.md) — SHACL Core constraints.
-- [Reasoning & Inference](reasoning-and-inference.md) — the Datalog alternative.
-
----
-
-## `sh:SPARQLConstraint` — custom validation
-
-A `sh:SPARQLConstraint` runs an `ASK` or `SELECT` query for every focus node. If the query returns true (for `ASK`) or any rows (for `SELECT`), pg_ripple records a violation.
-
-The classic example is *"a person's birth date must be earlier than their death date"* — not expressible in pure SHACL Core because it requires comparing two properties of the same node:
-
-```sql
-SELECT pg_ripple.load_shacl($TTL$
-@prefix sh:   <http://www.w3.org/ns/shacl#> .
-@prefix ex:   <https://example.org/> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/> .
-
-ex:LifeSpanShape a sh:NodeShape ;
-    sh:targetClass foaf:Person ;
-    sh:sparql [
-        sh:message  "Birth date must be earlier than death date" ;
-        sh:select   """
-            SELECT $this WHERE {
-                $this <https://example.org/birthDate> ?b ;
-                      <https://example.org/deathDate> ?d .
-                FILTER(?d <= ?b)
-            }
-        """ ;
-    ] .
-$TTL$);
-
--- Validate the whole store.
-SELECT focus_node, message FROM pg_ripple.shacl_validate();
-```
-
-Inside the query, the special variable `$this` is bound to the focus node. The query is evaluated by the same SPARQL engine you would use for any other query, so anything you can write in SPARQL — property paths, FILTER, BIND, sub-SELECT — is fair game inside a constraint.
 
 ---
 

--- a/docs/src/features/storing-knowledge.md
+++ b/docs/src/features/storing-knowledge.md
@@ -525,5 +525,5 @@ insert returns the existing SID. Use `deduplicate_all()` to clean up historical 
 
 ## Further reading
 
-- [Blog: RDF-star — Statements About Statements](../../blog/rdf-star-statements-about-statements.md) — edge properties and provenance on triples
-- [Blog: Vertical Partitioning Explained](../../blog/vertical-partitioning-explained.md) — why pg_ripple stores one table per predicate
+- [Blog: RDF-star — Statements About Statements](https://github.com/trickle-labs/pg-ripple/blob/main/blog/rdf-star-statements-about-statements.md) — edge properties and provenance on triples
+- [Blog: Vertical Partitioning Explained](https://github.com/trickle-labs/pg-ripple/blob/main/blog/vertical-partitioning-explained.md) — why pg_ripple stores one table per predicate

--- a/docs/src/features/temporal-and-provenance.md
+++ b/docs/src/features/temporal-and-provenance.md
@@ -177,5 +177,5 @@ That four-line chain is the kind of evidence a regulated industry needs and a bl
 
 ## Further reading
 
-- [Blog: Temporal Time-Travel Queries](../../blog/temporal-time-travel-queries.md) — point-in-time replay of your knowledge graph
-- [Blog: Provenance Tracking with PROV-O](../../blog/provenance-tracking-prov-o.md) — tracing where every fact came from
+- [Blog: Temporal Time-Travel Queries](https://github.com/trickle-labs/pg-ripple/blob/main/blog/temporal-time-travel-queries.md) — point-in-time replay of your knowledge graph
+- [Blog: Provenance Tracking with PROV-O](https://github.com/trickle-labs/pg-ripple/blob/main/blog/provenance-tracking-prov-o.md) — tracing where every fact came from

--- a/docs/src/features/uncertain-knowledge.md
+++ b/docs/src/features/uncertain-knowledge.md
@@ -238,6 +238,6 @@ above by 1.0, by the Knaster–Tarski fixed-point theorem the iteration converge
 
 ## Further reading
 
-- [Blog: Probabilistic Datalog](../../blog/probabilistic-datalog.md) — noisy-OR, confidence propagation, and soft reasoning in pg_ripple
-- [Blog: Uncertain Knowledge](../../blog/uncertain-knowledge.md) — practical patterns for probabilistic reasoning
+- [Blog: Probabilistic Datalog](https://github.com/trickle-labs/pg-ripple/blob/main/blog/probabilistic-datalog.md) — noisy-OR, confidence propagation, and soft reasoning in pg_ripple
+- [Blog: Uncertain Knowledge](https://github.com/trickle-labs/pg-ripple/blob/main/blog/uncertain-knowledge.md) — practical patterns for probabilistic reasoning
 

--- a/docs/src/features/validating-data-quality.md
+++ b/docs/src/features/validating-data-quality.md
@@ -506,4 +506,4 @@ FROM jsonb_array_elements(
 
 ## Further reading
 
-- [Blog: SHACL Data Quality](../../blog/shacl-data-quality.md) — a deep dive into how SHACL shapes protect your data
+- [Blog: SHACL Data Quality](https://github.com/trickle-labs/pg-ripple/blob/main/blog/shacl-data-quality.md) — a deep dive into how SHACL shapes protect your data

--- a/docs/src/features/vector-and-hybrid-search.md
+++ b/docs/src/features/vector-and-hybrid-search.md
@@ -183,4 +183,4 @@ Every vector function in pg_ripple checks for pgvector at call time. If pgvector
 
 ## Further reading
 
-- [Blog: Vector + SPARQL Hybrid Search](../../blog/vector-sparql-hybrid-search.md) — combining graph traversal with similarity search
+- [Blog: Vector + SPARQL Hybrid Search](https://github.com/trickle-labs/pg-ripple/blob/main/blog/vector-sparql-hybrid-search.md) — combining graph traversal with similarity search

--- a/docs/src/getting-started/key-concepts.md
+++ b/docs/src/getting-started/key-concepts.md
@@ -155,9 +155,9 @@ You never need to interact with dictionary IDs directly — `sparql()` and `find
 
 ## Further reading
 
-- [Blog: Why RDF Inside PostgreSQL?](../../blog/why-rdf-in-postgresql.md) — the design philosophy behind pg_ripple
-- [Blog: Dictionary Encoding and Integer Joins](../../blog/dictionary-encoding-integer-joins.md) — how pg_ripple achieves fast query performance
-- [Blog: Vertical Partitioning Explained](../../blog/vertical-partitioning-explained.md) — why one table per predicate works
+- [Blog: Why RDF Inside PostgreSQL?](https://github.com/trickle-labs/pg-ripple/blob/main/blog/why-rdf-in-postgresql.md) — the design philosophy behind pg_ripple
+- [Blog: Dictionary Encoding and Integer Joins](https://github.com/trickle-labs/pg-ripple/blob/main/blog/dictionary-encoding-integer-joins.md) — how pg_ripple achieves fast query performance
+- [Blog: Vertical Partitioning Explained](https://github.com/trickle-labs/pg-ripple/blob/main/blog/vertical-partitioning-explained.md) — why one table per predicate works
 
 ## Next steps
 

--- a/docs/src/guides/rule-library-federation.md
+++ b/docs/src/guides/rule-library-federation.md
@@ -8,8 +8,13 @@ second instance (instance B).
 
 - Two running pg_ripple 0.120.0+ instances with pg_ripple_http
 - Both HTTP companions accessible from each other over HTTPS
-- `ARROW_FLIGHT_SECRET` set to the same shared secret on both HTTP companions
-  (used for HMAC-authenticated stream endpoints)
+- `PG_RIPPLE_HTTP_AUTH_TOKEN` configured for read access to protected stream
+  endpoints. If `PG_RIPPLE_HTTP_DATALOG_WRITE_TOKEN` is set on the subscribing
+  instance, use it for the subscribe call; otherwise the main auth token is used.
+- The source stream must be reachable by the subscribing HTTP companion. The
+  current subscribe handler fetches `source_uri` directly and does not forward a
+  separate source Authorization header, so protect private streams with a
+  trusted internal network or gateway when source auth is required.
 
 ## Step 1 — Install a rule library on instance A
 
@@ -54,7 +59,8 @@ The HTTP companion immediately begins serving the stream at
 -- Connect to instance B
 \c ripple_b
 
--- Subscribe: fetches the rule stream from instance A and installs locally
+-- Record subscription intent. The SQL function validates the URI and catalog
+-- state, but the HTTP companion performs the actual fetch/install step.
 SELECT pg_ripple.subscribe_rule_library(
     'https://instance-a.example.com/rule-libraries/rdfs-entailment/stream',
     'rdfs-entailment'
@@ -66,7 +72,7 @@ Alternatively, use the HTTP API from instance B's companion:
 
 ```bash
 curl -X POST https://instance-b.example.com/rule-libraries/rdfs-entailment/subscribe \
-  -H "Authorization: Bearer $ARROW_FLIGHT_SECRET" \
+  -H "Authorization: Bearer $PG_RIPPLE_HTTP_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"source_uri": "https://instance-a.example.com/rule-libraries/rdfs-entailment/stream"}'
 ```
@@ -130,7 +136,7 @@ Add an alert rule for failed subscriptions:
 | Symptom | Likely cause | Fix |
 |---------|-------------|-----|
 | `PT0466: SSRF blocked` | `source_uri` resolves to a private IP | Use a public HTTPS endpoint; private addresses are blocked by the SSRF guard |
-| `remote returned HTTP 401` | Missing or wrong `ARROW_FLIGHT_SECRET` | Set matching `ARROW_FLIGHT_SECRET` on both companions |
+| `remote returned HTTP 401` | Source stream requires auth that the subscribing fetcher is not forwarding | Expose the source stream through a trusted internal route, or install the library manually from an authenticated client |
 | `PT0467: catalog write failed` | Insufficient DB permissions | Grant USAGE on `_pg_ripple` schema to the app role |
 | Inference not firing | Datalog engine not enabled | Run `SELECT pg_ripple.enable_datalog('rdfs-entailment');` |
 
@@ -139,4 +145,4 @@ Add an alert rule for failed subscriptions:
 - [`publish_rule_library` API reference](../reference/sql-api.md#publish_rule_library)
 - [`subscribe_rule_library` API reference](../reference/sql-api.md#subscribe_rule_library)
 - [Rule library Prometheus metrics](../operations/read-replicas.md)
-- [Blog: Rule Library Federation](../../blog/rule-library-federation.md)
+- [Blog: Rule Library Federation](https://github.com/trickle-labs/pg-ripple/blob/main/blog/rule-library-federation.md)

--- a/docs/src/operations/citus-integration.md
+++ b/docs/src/operations/citus-integration.md
@@ -1,9 +1,9 @@
-# Citus + pg_ripple + pg-trickle: End-to-End Integration Guide
+# Citus + pg_ripple: End-to-End Integration Guide
 
 > **Version**: v0.59.0 (CITUS-15)
 >
 > This guide covers deploying pg_ripple with Citus horizontal sharding and
-> pg-trickle CDC replication in a multi-worker environment.  It assumes you
+> optional CDC/IVM compatibility in a multi-worker environment. It assumes you
 > have already read the [Citus Integration](citus-integration.md) page.
 
 ---
@@ -17,7 +17,7 @@ The v0.58.0 + v0.59.0 releases complete the Citus sharding story:
 | VP table distribution | v0.58.0 | `enable_citus_sharding()` distributes VP delta tables |
 | Merge fence advisory lock | v0.58.0 | Prevents split-brain during rebalancing |
 | SPARQL shard-pruning | v0.59.0 | Bound-subject queries target one shard (10–100×) |
-| Rebalance NOTIFY | v0.59.0 | `merge_start`/`merge_end` signals for pg-trickle |
+| Rebalance NOTIFY | v0.59.0 | `merge_start`/`merge_end` signals for downstream maintenance hooks |
 | `explain_sparql` Citus section | v0.59.0 | Verify pruning with `EXPLAIN` |
 | `citus_rebalance_progress()` | v0.59.0 | Observe live rebalance status |
 
@@ -27,8 +27,8 @@ The v0.58.0 + v0.59.0 releases complete the Citus sharding story:
 
 1. **Citus 12+** installed on coordinator and all workers.
 2. **pg_ripple 0.59.0** installed on the coordinator.
-3. **pg-trickle 0.34.0+** (optional, for CDC streaming) with `handle_vp_promoted` 
-   wiring configured.
+3. Optional companions as needed: **pg_trickle 0.46.0+** for IVM-backed views,
+  and **pg_tide 0.33.0+** for relay/outbox CDC transport.
 
 ---
 
@@ -47,7 +47,7 @@ SELECT pg_ripple.citus_available();  -- returns true
 
 ```sql
 ALTER SYSTEM SET pg_ripple.citus_sharding_enabled = on;
--- Enable pg-trickle co-location compatibility (prevents cross-shard deletes):
+-- Enable legacy CDC/IVM co-location compatibility (prevents cross-shard deletes):
 ALTER SYSTEM SET pg_ripple.citus_trickle_compat = on;
 SELECT pg_reload_conf();
 ```
@@ -62,9 +62,9 @@ FROM pg_ripple.enable_citus_sharding();
 ```
 
 This performs for each VP delta table:
-1. `ALTER TABLE … REPLICA IDENTITY FULL` (required for pg-trickle logical replication)
+1. `ALTER TABLE … REPLICA IDENTITY FULL` (required for logical replication consumers)
 2. `create_distributed_table(…, 's', colocate_with => 'none')` (or `'default'`)
-3. `pg_notify('pg_ripple.vp_promoted', …)` — pg-trickle creates per-shard slots
+3. `pg_notify('pg_ripple.vp_promoted', …)` — downstream maintenance hooks can react
 
 ## Step 4: Verify shard-pruning (v0.59.0)
 
@@ -126,8 +126,8 @@ LISTEN "pg_ripple.merge_end";
 | GUC | Default | Description |
 |-----|---------|-------------|
 | `pg_ripple.citus_sharding_enabled` | `off` | Enable Citus shard distribution for VP tables |
-| `pg_ripple.citus_trickle_compat` | `off` | Use `colocate_with => 'none'` for pg-trickle CDC |
-| `pg_ripple.merge_fence_timeout_ms` | `0` | Max ms to wait for merge fence (0 = block indefinitely) |
+| `pg_ripple.citus_trickle_compat` | `off` | Use `colocate_with => 'none'` for legacy CDC/IVM compatibility |
+| `pg_ripple.merge_fence_timeout_ms` | `0` | Max ms to wait for merge fence (0 = no fence) |
 
 ---
 

--- a/docs/src/operations/pg-tide-relay.md
+++ b/docs/src/operations/pg-tide-relay.md
@@ -92,10 +92,11 @@ ERROR: pg_tide extension is not installed;
        then run: CREATE EXTENSION pg_tide
 ```
 
-If pg_trickle is not installed, SPARQL/Datalog/CONSTRUCT views are unavailable:
+If pg_trickle is not installed, IVM-backed SPARQL, Datalog, CONSTRUCT,
+DESCRIBE, ASK, and framing views are unavailable:
 
 ```
-WARNING: pg_trickle is not installed; CDC subscriptions are unavailable
+ERROR: pg_trickle is not installed -- SPARQL views require pg_trickle
 ```
 
 Call `pg_ripple.relay_available()` or `pg_ripple.pg_tide_available()` before

--- a/docs/src/operations/production-checklist.md
+++ b/docs/src/operations/production-checklist.md
@@ -55,7 +55,7 @@ Use this checklist before deploying pg_ripple to production. Each item links to 
 ## Optional Components
 
 - [ ] **pgvector** installed if using vector/hybrid search — `CREATE EXTENSION vector` ([Vector Search](../features/vector-and-hybrid-search.md))
-- [ ] **pg_trickle** installed if using live views or CDC bridge — ([CDC Operations](cdc.md))
+- [ ] **pg_trickle** installed if using live views; **pg_tide** installed if using the CDC bridge or relay outboxes — ([CDC Operations](cdc.md))
 - [ ] **PostGIS** installed if using GeoSPARQL — ([GeoSPARQL](../features/geospatial.md))
 
 ## Smoke Test

--- a/docs/src/operations/read-replicas.md
+++ b/docs/src/operations/read-replicas.md
@@ -97,5 +97,5 @@ groups:
 ## See also
 
 - [Configuration reference](../reference/guc-reference.md)
-- [Observability](observability.md)
+- [OpenTelemetry observability](observability-otel.md)
 - [Compatibility matrix](compatibility.md)

--- a/docs/src/operations/scaling.md
+++ b/docs/src/operations/scaling.md
@@ -236,12 +236,12 @@ default_pool_size = 20
 | Concurrent SPARQL queries | Hundreds (with pooler) | Bound by `max_connections` and CPU |
 | Write throughput | ~50K–200K triples/sec (bulk load) | Single-writer architecture |
 | Read replicas | Unlimited | Standard PG replication |
-| Cross-node sharding | **Supported** (Citus 12+, v0.58.0+) | Subject-hash distribution; see [Citus sharding](citus-sharding.md) |
+| Cross-node sharding | **Supported** (Citus 12+, v0.58.0+) | Subject-hash distribution; see [Citus integration](citus-integration.md) |
 | Multi-primary writes | **Not supported** | PostgreSQL limitation |
 | Federation | Supported (SERVICE clause) | Remote endpoints add latency |
 
 ```admonish tip title="Horizontal sharding with Citus"
-pg_ripple v0.58.0+ supports distributing VP tables across Citus worker nodes. Triples are hash-sharded by subject ID so star-pattern queries co-locate on a single worker. v0.59.0 adds SPARQL shard-pruning (10–100× speedup for bound-subject queries). See [Citus Horizontal Sharding](citus-sharding.md) for setup instructions.
+pg_ripple v0.58.0+ supports distributing VP tables across Citus worker nodes. Triples are hash-sharded by subject ID so star-pattern queries co-locate on a single worker. v0.59.0 adds SPARQL shard-pruning (10–100× speedup for bound-subject queries). See [Citus integration](citus-integration.md) for setup instructions.
 ```
 
 ---

--- a/docs/src/reference/conformance-trends.md
+++ b/docs/src/reference/conformance-trends.md
@@ -1,25 +1,24 @@
 # Conformance Trends
 
-> **T13-04 (v0.86.0)**: this page tracks pg_ripple's pass rates across all five conformance suites over time.
+> **T13-04 (v0.86.0)**: this page explains how pg_ripple tracks pass rates across the conformance suites over time.
 
-The raw data is in [`tests/conformance/history.csv`](../../tests/conformance/history.csv). The CI job `conformance-trends` appends a row after each successful main-branch build.
+The raw trend data lives in the repository at
+[`tests/conformance/history.csv`](https://github.com/trickle-labs/pg-ripple/blob/main/tests/conformance/history.csv).
+The CI job `conformance-trends` appends a row after successful main-branch
+builds. This page does not duplicate the CSV inline, because copied trend rows
+go stale quickly and can drift from the CI artifact.
 
 ---
 
-## Pass Rate History
+## Current Release Gates
 
-| Version | Suite | Total | Passed | Failed | Skipped | Date |
-|---|---|---|---|---|---|---|
-| 0.85.0 | w3c-sparql-11 | 357 | 357 | 0 | 0 | 2026-07-17 |
-| 0.85.0 | apache-jena | 1021 | 1019 | 2 | 0 | 2026-07-17 |
-| 0.85.0 | watdiv | 100 | 100 | 0 | 0 | 2026-07-17 |
-| 0.85.0 | lubm | 14 | 14 | 0 | 0 | 2026-07-17 |
-| 0.85.0 | owl2rl | 258 | 256 | 2 | 0 | 2026-07-17 |
-| 0.86.0 | w3c-sparql-11 | 357 | 357 | 0 | 0 | 2026-05-02 |
-| 0.86.0 | apache-jena | 1021 | 1019 | 2 | 0 | 2026-05-02 |
-| 0.86.0 | watdiv | 100 | 100 | 0 | 0 | 2026-05-02 |
-| 0.86.0 | lubm | 14 | 14 | 0 | 0 | 2026-05-02 |
-| 0.86.0 | owl2rl | 258 | 256 | 2 | 0 | 2026-05-02 |
+| Suite | Current CI role | Release expectation |
+|---|---|---|
+| W3C SPARQL 1.1 | Smoke subset is blocking; full suite is informational | Smoke subset must pass |
+| Apache Jena | Informational until the project consistently clears the threshold | Target pass rate ≥ 95% |
+| WatDiv | Correctness and performance signal | Non-blocking, reviewed for regressions |
+| LUBM | OWL RL reasoning gate | Required |
+| OWL 2 RL | Entailment conformance signal | Informational until ≥ 95% pass rate |
 
 ---
 
@@ -37,14 +36,10 @@ The raw data is in [`tests/conformance/history.csv`](../../tests/conformance/his
 
 ## CI Badges (v0.122.0)
 
-The Apache Jena pass rate is published as a CI badge after each main-branch build.
-The badge JSON is written to `results/jena-badge.json` by the `jena-suite` CI job.
-
-To reference the current pass rate in documentation or a README:
-
-```markdown
-![Jena](results/jena-badge.json)
-```
+The Apache Jena pass rate is published as a CI badge after each main-branch
+build. The `jena-suite` CI job writes the generated badge payload to
+`results/jena-badge.json` in the workflow artifact; the file may not exist in a
+fresh local checkout until that job has run.
 
 The badge data format follows the [shields.io endpoint schema](https://shields.io/endpoint):
 

--- a/docs/src/reference/construct-rules.md
+++ b/docs/src/reference/construct-rules.md
@@ -63,6 +63,6 @@ dependency order after each write.
 
 ## Related Pages
 
-- [SPARQL CONSTRUCT writeback guide](../../user-guide/construct-views.md)
+- [Live Views and Subscriptions](../features/live-views-and-subscriptions.md)
 - [Architecture Internals](architecture.md)
 - [Feature Status Taxonomy](feature-status-taxonomy.md)

--- a/docs/src/reference/degradation.md
+++ b/docs/src/reference/degradation.md
@@ -180,15 +180,15 @@ but O(n) in the number of embeddings. Install pgvector for production vector wor
 | Property | Value |
 |---|---|
 | Status in v0.63.0 | `experimental` |
-| Dependency | `pg_trickle` extension |
-| Return on missing pg_trickle | Subscriptions fail with informational error |
-| Warning code | `WARNING: pg_trickle is not installed; CDC subscriptions are unavailable` |
-| Readiness behavior | Reported as `experimental` in `/ready` with degraded_reason |
+| Dependency | None for subscription catalog registration; pg_tide is required only for relay/outbox transport |
+| Return when pg_tide is missing | `create_subscription()` still records the subscription; relay-dependent delivery paths are unavailable |
+| Readiness behavior | Reported as `experimental` in `/ready` while the subscription surface remains pre-1.0 |
 
-**Detail**: Live CDC subscriptions use pg_trickle stream tables for efficient
-change propagation. Without pg_trickle, `create_subscription()` returns an
-informational message rather than creating a subscription. The extension does
-not panic or raise an unrecoverable error.
+**Detail**: `create_subscription()` writes subscription metadata into
+`_pg_ripple.subscriptions` and does not require pg_trickle. Relay/outbox
+pipelines that publish changes to external systems require pg_tide; when pg_tide
+is absent, those relay paths degrade, but the subscription catalog API remains
+available.
 
 ---
 

--- a/docs/src/reference/geosparql-functions.md
+++ b/docs/src/reference/geosparql-functions.md
@@ -81,4 +81,4 @@ CREATE EXTENSION postgis;
 CREATE EXTENSION pg_ripple CASCADE;
 ```
 
-See [GeoSPARQL + PostGIS Integration](../../blog/geosparql-postgis-spatial.md) for a full tutorial.
+See [GeoSPARQL + PostGIS Integration](https://github.com/trickle-labs/pg-ripple/blob/main/blog/geosparql-postgis-spatial.md) for a full tutorial.

--- a/docs/src/reference/guc-reference.md
+++ b/docs/src/reference/guc-reference.md
@@ -1446,7 +1446,7 @@ Legacy name for the pg_tide outbox that the CDC bridge worker publishes JSON-LD 
 |---|---|
 | Type | Boolean |
 | Default | `on` |
-| Context | `sighup` |
+| Context | `userset` |
 | Since | v0.52.0 |
 
 Legacy master switch for relay bridge integration features. When `off`, CDC bridge code paths are disabled even when pg_tide is installed. Use `pg_ripple.pg_trickle_available()` separately for IVM-backed live views.
@@ -1498,10 +1498,10 @@ Enable Citus horizontal sharding of VP tables. When `on`, new VP tables are crea
 |---|---|
 | Type | Boolean |
 | Default | `off` |
-| Context | `postmaster` |
+| Context | `userset` |
 | Since | v0.58.0 |
 
-When `on`, `create_distributed_table` uses `colocate_with = 'none'` for pg-trickle/CDC compatibility. Prevents cross-shard tombstone deletes.
+When `on`, `create_distributed_table` uses `colocate_with = 'none'` for legacy CDC/IVM compatibility. Prevents cross-shard tombstone deletes.
 
 ---
 

--- a/docs/src/reference/http-api.md
+++ b/docs/src/reference/http-api.md
@@ -33,67 +33,118 @@ Read-only endpoints (`GET /health`, `GET /metrics`, `GET /openapi.yaml`) do not 
 | `PG_RIPPLE_HTTP_PORT` | `7878` | TCP listening port |
 | `PG_RIPPLE_HTTP_POOL_SIZE` | `16` | PostgreSQL connection pool size |
 | `PG_RIPPLE_HTTP_AUTH_TOKEN` | *(none)* | Bearer token; set to enable auth |
-| `PG_RIPPLE_HTTP_RATE_LIMIT` | `0` | Per-IP rate limit (req/s; 0 = unlimited) |
-| `PG_RIPPLE_HTTP_CORS_ORIGINS` | `*` | Comma-separated allowed CORS origins |
+| `PG_RIPPLE_HTTP_DATALOG_WRITE_TOKEN` | *(falls back to auth token)* | Optional separate token for mutating Datalog/rule endpoints |
+| `PG_RIPPLE_HTTP_RATE_LIMIT` | `100` | Per-IP rate limit (req/s; 0 = unlimited) |
+| `PG_RIPPLE_HTTP_CORS_ORIGINS` | `''` | Comma-separated allowed CORS origins; `*` enables permissive CORS |
 | `PG_RIPPLE_HTTP_MAX_BODY_BYTES` | `10485760` | Max request body size (10 MiB) |
 | `PG_RIPPLE_HTTP_SKIP_COMPAT_CHECK` | *(unset)* | Set to `1` to skip extension version check |
+| `PG_RIPPLE_HTTP_STRICT_COMPAT` | *(unset)* | Set to `1` to fail startup on incompatible extension versions |
+| `PG_RIPPLE_HTTP_METRICS_TOKEN` | *(none)* | Optional bearer token for `/metrics` |
+| `PG_RIPPLE_HTTP_AUTH_REALM` | `pg_ripple` | `WWW-Authenticate` realm for 401 responses |
+| `PG_RIPPLE_HTTP_REPLICA_DSN` | *(none)* | Optional read-replica PostgreSQL DSN |
+| `PG_RIPPLE_HTTP_TRUST_PROXY` | *(none)* | Trusted upstream proxy IP/CIDR list for forwarded headers |
+| `PG_RIPPLE_HTTP_CA_BUNDLE` | *(system roots)* | Extra CA bundle for outbound HTTPS clients |
+| `PG_RIPPLE_HTTP_PIN_FINGERPRINTS` | *(none)* | Optional pinned TLS certificate fingerprints |
+| `PG_RIPPLE_HTTP_SHUTDOWN_TIMEOUT_SECS` | `30` | Graceful shutdown timeout |
+| `ARROW_FLIGHT_SECRET` | *(none)* | HMAC secret for Arrow Flight tickets |
+| `ARROW_UNSIGNED_TICKETS_ALLOWED` | `false` | Allow unsigned Arrow tickets for local development |
+| `ARROW_NONCE_CACHE_MAX` | `10000` | Replay-protection nonce cache size |
 
 ---
 
 ## Complete Endpoint Reference
 
+`Read` and `Write` mean the endpoint calls the HTTP companion's read or write
+authentication check when `PG_RIPPLE_HTTP_AUTH_TOKEN` is configured. `None` means
+the endpoint is intentionally unauthenticated.
+
 | Method | Path | Auth | Description |
 |---|---|---|---|
-| `GET` | `/sparql` | Optional | SPARQL 1.1 query via URL parameters |
-| `POST` | `/sparql` | Optional | SPARQL 1.1 query/update via request body |
-| `POST` | `/sparql/stream` | Optional | Streaming SPARQL SELECT (SSE) |
-| `POST` | `/rag` | Optional | RAG retrieval / NL-to-SPARQL |
+| `GET` | `/sparql` | Read | SPARQL 1.1 query via URL parameters |
+| `POST` | `/sparql` | Query-dependent | SPARQL 1.1 query/update via request body; updates require write auth |
+| `POST` | `/sparql/stream` | Read | Streaming SPARQL SELECT (SSE) |
+| `POST` | `/rag` | Read | RAG retrieval / NL-to-SPARQL |
 | `GET` | `/health` | None | Liveness probe |
-| `GET` | `/ready` | None | Readiness probe (alias) |
-| `GET` | `/health/ready` | None | Readiness probe |
-| `GET` | `/metrics` | None | Prometheus metrics |
+| `GET` | `/ready` | None | Kubernetes readiness probe |
+| `GET` | `/health/ready` | None | Deep extension readiness probe |
+| `GET` | `/metrics` | None or metrics token | Prometheus metrics |
 | `GET` | `/metrics/extension` | None | Extension-internal Prometheus metrics |
 | `GET` | `/void` | None | VoID dataset description |
 | `GET` | `/service` | None | SPARQL service description |
 | `GET` | `/openapi.yaml` | None | OpenAPI 3.1 specification |
-| `GET` | `/explorer` | None | Web-based SPARQL explorer UI |
-| `POST` | `/flight/do_get` | Required | Arrow Flight bulk export |
-| `GET` | `/subscribe/{id}` | Optional | SSE subscription stream |
-| `GET` | `/datalog/rules` | Optional | List Datalog rule sets |
-| `GET/DELETE` | `/datalog/rules/{rule_set}` | Required | Get or drop a rule set |
-| `GET` | `/datalog/rules/{rule_set}/builtin` | Optional | Get built-in rules for a rule set |
-| `POST` | `/datalog/rules/{rule_set}/add` | Required | Add a rule to a rule set |
-| `POST` | `/datalog/rules/{rule_set}/enable` | Required | Enable a rule set |
-| `POST` | `/datalog/rules/{rule_set}/disable` | Required | Disable a rule set |
-| `DELETE` | `/datalog/rules/{rule_set}/{rule_id}` | Required | Delete a specific rule |
-| `POST` | `/datalog/infer/{rule_set}` | Required | Run forward-chaining inference |
-| `POST` | `/datalog/infer/{rule_set}/agg` | Required | Run inference with aggregation |
-| `POST` | `/datalog/infer/{rule_set}/wfs` | Required | Run well-founded semantics inference |
-| `POST` | `/datalog/infer/{rule_set}/demand` | Required | Goal-directed demand inference |
-| `POST` | `/datalog/infer/{rule_set}/lattice` | Required | Lattice-based inference |
-| `GET` | `/datalog/infer/{rule_set}/stats` | Optional | Inference stats for rule set |
-| `POST` | `/datalog/query/{rule_set}` | Optional | Goal-directed Datalog query |
-| `GET` | `/datalog/constraints` | Optional | Check all constraint rules |
-| `GET` | `/datalog/constraints/{rule_set}` | Optional | Check constraints for one rule set |
-| `GET` | `/datalog/stats/cache` | Optional | Rule plan cache statistics |
-| `GET` | `/datalog/stats/tabling` | Optional | Tabling cache statistics |
-| `GET` | `/datalog/lattices` | Optional | List active lattice structures |
-| `GET` | `/datalog/views` | Optional | List Datalog-backed views |
-| `DELETE` | `/datalog/views/{name}` | Required | Drop a Datalog-backed view |
-| `POST` | `/pagerank/run` | Required | Start PageRank computation |
-| `GET` | `/pagerank/status` | Optional | PageRank computation status |
-| `GET` | `/pagerank/results` | Optional | Retrieve PageRank scores |
-| `GET` | `/pagerank/export` | Optional | Export PageRank scores |
-| `GET` | `/pagerank/explain/{node_iri}` | Optional | Explain PageRank score for a node |
-| `GET` | `/pagerank/queue-stats` | Optional | PageRank queue statistics |
-| `POST` | `/pagerank/vacuum-dirty` | Required | Vacuum stale PageRank rows |
-| `POST` | `/centrality/run` | Required | Compute centrality metrics |
-| `GET` | `/centrality/results` | Optional | Retrieve centrality results |
-| `POST` | `/pagerank/find-duplicates` | Optional | Find near-duplicate nodes |
-| `POST` | `/confidence/load` | Required | Load triples with confidence scores |
-| `GET` | `/confidence/shacl-score` | Optional | Get SHACL soft-validation scores |
-| `GET` | `/confidence/shacl-report` | Optional | Get scored SHACL validation report |
-| `POST` | `/confidence/vacuum` | Required | Vacuum stale confidence rows |
+| `GET` | `/explorer` | Read | Web-based SPARQL explorer UI |
+| `GET` | `/admin/bench-history` | Write | Recent benchmark history from `_pg_ripple.bench_history` |
+| `GET` | `/admin/diagnostic-snapshot` | Write | Diagnostic bundle with schema, GUC, version, and metrics data |
+| `POST` | `/flight/do_get` | Write | Arrow Flight bulk export |
+| `GET` | `/subscribe/{subscription_id}` | Read | Live SPARQL subscription SSE stream |
+| `GET` | `/datalog/rules` | Read | List Datalog rule sets |
+| `POST/DELETE` | `/datalog/rules/{rule_set}` | Write | Load or drop a rule set |
+| `POST` | `/datalog/rules/{rule_set}/builtin` | Write | Load built-in rules for a rule set |
+| `POST` | `/datalog/rules/{rule_set}/add` | Write | Add a rule to a rule set |
+| `PUT` | `/datalog/rules/{rule_set}/enable` | Write | Enable a rule set |
+| `PUT` | `/datalog/rules/{rule_set}/disable` | Write | Disable a rule set |
+| `DELETE` | `/datalog/rules/{rule_set}/{rule_id}` | Write | Delete a specific rule |
+| `POST` | `/datalog/infer/{rule_set}` | Write | Run forward-chaining inference |
+| `POST` | `/datalog/infer/{rule_set}/stats` | Write | Run inference and return stats |
+| `POST` | `/datalog/infer/{rule_set}/agg` | Write | Run inference with aggregation |
+| `POST` | `/datalog/infer/{rule_set}/wfs` | Write | Run well-founded semantics inference |
+| `POST` | `/datalog/infer/{rule_set}/demand` | Write | Goal-directed demand inference |
+| `POST` | `/datalog/infer/{rule_set}/lattice` | Write | Lattice-based inference |
+| `POST` | `/datalog/query/{rule_set}` | Read | Goal-directed Datalog query |
+| `GET` | `/datalog/constraints` | Read | Check all constraint rules |
+| `GET` | `/datalog/constraints/{rule_set}` | Read | Check constraints for one rule set |
+| `GET` | `/datalog/stats/cache` | Read | Rule plan cache statistics |
+| `GET` | `/datalog/stats/tabling` | Read | Tabling cache statistics |
+| `GET/POST` | `/datalog/lattices` | Read/Write | List or create lattice structures |
+| `GET/POST` | `/datalog/views` | Read/Write | List or create Datalog-backed views |
+| `DELETE` | `/datalog/views/{name}` | Write | Drop a Datalog-backed view |
+| `POST` | `/pagerank/run` | Write | Start PageRank computation |
+| `GET` | `/pagerank/status` | Read | PageRank computation status |
+| `GET` | `/pagerank/results` | Read | Retrieve PageRank scores |
+| `GET` | `/pagerank/export` | Read | Export PageRank scores |
+| `GET` | `/pagerank/explain/{node_iri}` | Read | Explain PageRank score for a node |
+| `GET` | `/pagerank/queue-stats` | Read | PageRank queue statistics |
+| `POST` | `/pagerank/vacuum-dirty` | Write | Vacuum stale PageRank rows |
+| `POST` | `/centrality/run` | Write | Compute centrality metrics |
+| `GET` | `/centrality/results` | Read | Retrieve centrality results |
+| `POST` | `/pagerank/find-duplicates` | Read | Find near-duplicate nodes |
+| `POST` | `/confidence/load` | Write | Load triples with confidence scores |
+| `GET` | `/confidence/shacl-score` | Read | Get SHACL soft-validation scores |
+| `GET` | `/confidence/shacl-report` | Read | Get scored SHACL validation report |
+| `POST` | `/confidence/vacuum` | Write | Vacuum stale confidence rows |
+| `POST` | `/confidence/update` | Write | Run Bayesian confidence update |
+| `POST` | `/confidence/bulk-update` | Write | Bulk confidence update |
+| `POST` | `/explain` | Read | Natural-language explanation of a query or result |
+| `GET` | `/explain` | Read | Explanation endpoint metadata/query form |
+| `POST` | `/hypothetical` | Write | What-if reasoning against hypothetical facts |
+| `GET` | `/rule-conflicts/{ruleset}` | Read | Detect rule conflicts in a rule set |
+| `GET` | `/rule-libraries` | Read | List rule libraries |
+| `GET` | `/rule-libraries/{name}/stream` | Read | Stream a published rule library |
+| `POST` | `/rule-libraries/{name}/subscribe` | Write | Subscribe to a remote rule library stream |
+| `POST` | `/rules/draft` | Write | Draft rules from natural-language guidance |
+| `POST` | `/rules/validate` | Write | Validate a drafted rule |
+| `GET` | `/rules/{id}/explain` | Read | Explain a rule by ID |
+| `GET/POST` | `/temporal/mark` | Read/Write | List or mark temporal predicates |
+| `POST` | `/temporal/point_in_time` | Write | Set point-in-time temporal context |
+| `GET` | `/temporal/facts` | Read | List temporal facts |
+| `GET` | `/temporal/graphs/{iri}/snapshot` | Read | Materialize a point-in-time graph snapshot |
+| `GET` | `/temporal/graphs/{iri}/diff` | Read | Diff a named graph between two timestamps |
+| `POST` | `/pprl/bloom_encode` | Write | Privacy-preserving Bloom encoding |
+| `POST` | `/pprl/dice_similarity` | Read | Dice similarity over encoded values |
+| `POST` | `/dp/noisy_count` | Read | Differential privacy noisy count |
+| `POST` | `/dp/noisy_histogram` | Read | Differential privacy noisy histogram |
+| `GET` | `/dp/budget/{dataset}/{principal}` | Read | Privacy budget status |
+| `POST` | `/entity-resolution/resolve` | Write | Run entity resolution |
+| `POST` | `/entity-resolution/evaluate` | Read | Evaluate entity-resolution output |
+| `POST` | `/entity-resolution/monitoring/enable` | Write | Enable entity-resolution monitoring |
+| `POST` | `/entity-resolution/monitoring/disable` | Write | Disable entity-resolution monitoring |
+| `GET` | `/proof-tree/{subject}/{predicate}/{object}` | Read | Explain derivation/proof tree for a triple |
+| `GET/POST` | `/tenants` | Read/Write | List or create tenants |
+| `GET/DELETE` | `/tenants/{name}` | Read/Write | Get or delete a tenant |
+| `GET/POST` | `/tenants/{name}/quota` | Read/Write | Get or update tenant quota |
+| `GET` | `/federation/{endpoint}/auth-status` | Write | Per-endpoint federation credential status |
+| `POST` | `/json-mapping/{name}/writeback` | Write | Synchronous JSON mapping relational writeback |
+| `GET` | `/json-mapping/{name}/writeback/status` | Read | JSON mapping writeback queue status |
 
 ---
 
@@ -237,6 +288,57 @@ Execute a hybrid SPARQL + vector-similarity RAG retrieval query. The endpoint em
 ```
 
 The `context` field is a concatenated plain-text summary ready for use as an LLM system prompt.
+
+---
+
+## JSON Mapping Writeback
+
+### `POST /json-mapping/{name}/writeback`
+
+Synchronously write one RDF subject back to the relational table configured for
+the named JSON mapping. This calls `pg_ripple.writeback_json_row(name,
+subject_iri)` and requires write auth when authentication is enabled.
+
+**Content-Type:** `application/json`
+
+```json
+{
+  "subject_iri": "https://example.com/contacts/c001"
+}
+```
+
+**Response (200 OK):**
+
+```json
+{
+  "rows_affected": 1
+}
+```
+
+**Error mapping:**
+
+| Status | Error | Cause |
+|---|---|---|
+| `422` | `writeback_target_not_configured` | The mapping has no writeback table or key columns (`PT0550`) |
+| `409` | `writeback_conflict` | Conflict policy is `error` and a conflicting row exists (`PT0551`) |
+
+### `GET /json-mapping/{name}/writeback/status`
+
+Return queue depth, error count, and last processed timestamp for one mapping.
+This is a filtered HTTP view over `pg_ripple.json_writeback_status()` and
+requires read auth when authentication is enabled.
+
+**Response (200 OK):**
+
+```json
+{
+  "mapping_name": "contacts",
+  "pending": 0,
+  "errors": 0,
+  "last_error": null,
+  "last_processed_at": null
+}
+```
 
 ---
 

--- a/docs/src/reference/shacl.md
+++ b/docs/src/reference/shacl.md
@@ -57,5 +57,5 @@ existing data.
 ## Related Pages
 
 - [SHACL SQL Reference](../user-guide/sql-reference/shacl.md)
-- [SHACL Data Quality Guide](../../user-guide/shacl.md)
+- [Validating Data Quality](../features/validating-data-quality.md)
 - [Feature Status Taxonomy](feature-status-taxonomy.md)

--- a/docs/src/reference/sql-api.md
+++ b/docs/src/reference/sql-api.md
@@ -122,7 +122,7 @@ SELECT * FROM pg_ripple.bench_workload_result('bsbm');
 ### `publish_rule_library`
 
 Publish an installed rule library so it can be subscribed to from remote
-pg_ripple instances over Arrow Flight.
+pg_ripple instances through the HTTP companion's rule-library stream endpoint.
 
 ```sql
 pg_ripple.publish_rule_library(
@@ -136,7 +136,7 @@ pg_ripple.publish_rule_library(
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | `TEXT` | Name of an installed rule library (1–64 alphanumeric/hyphen/underscore chars) |
-| `endpoint_uri` | `TEXT` | Full HTTP URI at which the Arrow Flight stream will be served, e.g. `'https://host/rule-libraries/my-lib/stream'` |
+| `endpoint_uri` | `TEXT` | Full HTTP URI at which the rule stream will be served, e.g. `'https://host/rule-libraries/my-lib/stream'` |
 
 **Errors** — raises `PT046x` error codes for invalid name/URI, missing library,
 or catalog write failure.
@@ -151,8 +151,10 @@ SELECT pg_ripple.publish_rule_library(
 
 ### `subscribe_rule_library`
 
-Fetch a rule library from a remote Arrow Flight stream endpoint and install it
-locally.  The source URI must pass the SSRF blocklist.
+Record the intent to subscribe to a remote rule-library stream. The source URI
+must pass the SSRF policy check. The SQL function does not perform outbound
+network I/O; fetching and installing the remote rules is performed by the HTTP
+companion's `POST /rule-libraries/{name}/subscribe` endpoint.
 
 ```sql
 pg_ripple.subscribe_rule_library(
@@ -168,11 +170,11 @@ pg_ripple.subscribe_rule_library(
 | `source_uri` | `TEXT` | Full HTTP URI of the remote stream endpoint |
 | `name` | `TEXT` | Local name to use for the subscribed rule library |
 
-**Errors** — raises `PT046x` error codes for SSRF-blocked URIs, network
-failures, invalid names, or catalog write failure.
+**Errors** — raises `PT046x` error codes for SSRF-blocked URIs, invalid names,
+or catalog write failure.
 
 ```sql
--- Subscribe to a rule library published on instance A:
+-- Record subscription intent for a rule library published on instance A:
 SELECT pg_ripple.subscribe_rule_library(
     'https://instance-a.example.com/rule-libraries/rdfs-base/stream',
     'rdfs-base'

--- a/justfile
+++ b/justfile
@@ -188,6 +188,35 @@ docker tag="local": (docker-build tag) (docker-run tag)
 docs-serve:
     mdbook serve docs --open
 
+# Build docs with mdBook (succeeds without mdbook-admonish; install it for styled callouts)
+[group: "docs"]
+docs-build:
+    mdbook build docs
+
+# Check that all relative Markdown links in docs/ resolve to real files
+[group: "docs"]
+docs-check-links:
+    python3 scripts/check_docs_links.py
+
+# Check that every docs/src/*.md page is referenced in SUMMARY.md
+[group: "docs"]
+docs-check-summary:
+    python3 scripts/check_docs_summary.py
+
+# Report GUC defaults that differ between src/gucs/ and the documentation (non-blocking)
+[group: "docs"]
+docs-check-guc-drift:
+    python3 scripts/check_guc_drift.py
+
+# Report HTTP routes in routing/mod.rs that are not listed in http-api.md (non-blocking)
+[group: "docs"]
+docs-check-http-routes:
+    python3 scripts/check_http_routes.py
+
+# Run all docs validation checks (links, summary, GUC drift, HTTP routes)
+[group: "docs"]
+docs-check: docs-check-links docs-check-summary docs-check-guc-drift docs-check-http-routes
+
 # ── Release ───────────────────────────────────────────────────────────────
 
 # Prepare a new release: bump version in Cargo.toml and pg_ripple.control,

--- a/plans/documentation-2.md
+++ b/plans/documentation-2.md
@@ -1,0 +1,356 @@
+# Documentation Quality Improvement Plan
+
+> Date: 2026-05-22
+> Scope: `docs/`, `docs/src/`, and documentation cross-links into `blog/`, `plans/`, code, SQL migrations, and `pg_ripple_http`.
+> Current baseline: pg_ripple v0.128.0, PostgreSQL 18, pgrx 0.18, mdBook documentation with 178 source pages under `docs/src/`.
+
+## 1. Goals
+
+The documentation should be trustworthy, easy to navigate, and cheaper to keep correct as the implementation changes. The primary goal is not more prose; it is a tighter loop between the codebase and the docs so users can rely on examples, references, compatibility statements, and operational guidance.
+
+Success means:
+
+- Every page in `docs/src/` is reachable from `SUMMARY.md` and every local source link resolves.
+- The docs build locally with `mdbook build docs` on a fresh contributor machine, even when optional preprocessors are absent.
+- SQL function, GUC, HTTP route, environment-variable, and error-code references match the implementation.
+- Feature pages explain what is implemented now, what is optional or degraded, and what companion extension is required.
+- Duplicated pages are either merged, clearly split by audience, or replaced with short index/recipe pages.
+- Code examples are executable or explicitly marked as schematic.
+- Release work includes a repeatable docs verification step before tagging.
+
+## 2. Baseline Findings From This Audit
+
+This audit found the documentation broadly complete but carrying several kinds of drift:
+
+| Area | Finding | Current action |
+|---|---|---|
+| Navigation | `docs/src/SUMMARY.md` covers all 178 mdBook source pages; no orphan pages were found. | Preserve this standard with an automated check. |
+| Local links | The first source-link scan found 47 missing local targets, mostly links from mdBook pages to top-level `blog/` posts using the wrong relative path. | Rewrote blog links to stable repository URLs and fixed stale local links. |
+| Build tooling | `mdbook build docs` failed on machines without `mdbook-admonish`. | Make `mdbook-admonish` optional while preserving admonish rendering when installed. |
+| HTTP reference | `docs/src/reference/http-api.md` claimed to be complete but missed newer routes and had stale methods/auth labels for Datalog endpoints. | Updated the endpoint inventory and added JSON mapping writeback endpoints. |
+| GUC reference | `docs/gucs.md` had stale defaults/types for several implemented GUCs. | Corrected the identified values and context labels. |
+| Companion extensions | Some pages still blurred pg_trickle and pg_tide responsibilities after the relay migration. | Clarified that pg_trickle is IVM-only and pg_tide owns relay/outbox/inbox transport. |
+| Duplication | Rule-library federation had overlapping cookbook and guide pages. | Converted the cookbook entry into a short recipe and kept the guide as the detailed walkthrough. |
+| Historical docs | `docs/GAP_ANALYSIS.md` and `docs/IMPROVEMENT_PLAN.md` describe v0.99.1-era issues and should not be read as current state. | Mark them as historical and superseded by this plan. |
+
+## 3. Workstream A: Automated Docs Validation
+
+### A1. Add a Source Link Checker
+
+Create `scripts/check_docs_links.py` or a Rust equivalent that scans Markdown files under `docs/` and verifies:
+
+- Internal relative links resolve to an existing source file.
+- Links to directories resolve to `README.md` or `index.md` when appropriate.
+- Fragment-only anchors are ignored in the first version, then checked in a later pass.
+- External links are reported separately and can be checked only in scheduled CI to avoid flaky PR failures.
+- Links into top-level `blog/`, `plans/`, `tests/`, and `results/` are either valid source links or deliberate external repository links.
+
+Add a `just docs-check-links` target and run it in CI.
+
+Definition of done:
+
+- The checker exits non-zero on missing local files.
+- The checker prints file, line, raw target, and resolved target.
+- CI runs it on every pull request that touches Markdown or docs tooling.
+
+### A2. Add a SUMMARY Coverage Check
+
+Create `scripts/check_docs_summary.py` to compare `docs/src/SUMMARY.md` against all `docs/src/**/*.md` files.
+
+Rules:
+
+- Every mdBook page except `SUMMARY.md` must be linked exactly once unless explicitly allowlisted.
+- Allowlisted pages must explain why they are intentionally hidden.
+- Duplicate entries should fail CI unless one is a deliberate redirect/index entry.
+
+Definition of done:
+
+- The current tree reports 0 orphan pages.
+- The check catches new pages that are not added to navigation.
+
+### A3. Make mdBook Build Reproducible
+
+Keep `mdbook-admonish` optional for local builds, but document the enhanced build path:
+
+```bash
+cargo install mdbook mdbook-admonish
+mdbook build docs
+```
+
+Add `just docs-build` to run `mdbook build docs` and a CI job that installs `mdbook-admonish` so production output keeps styled callouts.
+
+Definition of done:
+
+- `mdbook build docs` succeeds without `mdbook-admonish`.
+- CI still tests the styled admonish path.
+- `docs/book/` generated output is either consistently ignored or regenerated only by a documented release step.
+
+## 4. Workstream B: Generated Reference Sources
+
+### B1. Generate the GUC Reference
+
+The repo has two GUC reference surfaces: `docs/gucs.md` and `docs/src/reference/guc-reference.md`. They should be generated or checked from `src/gucs/**` and `src/gucs/registration/**`.
+
+Implementation steps:
+
+1. Parse GUC registration calls in `src/gucs/registration/**/*.rs`.
+2. Extract name, type, default, min/max where available, context, and short description.
+3. Cross-check defaults against `GucSetting::new(...)` declarations.
+4. Emit a machine-readable intermediate file such as `target/docs/gucs.json`.
+5. Generate the tabular `docs/gucs.md` from that intermediate file.
+6. For `guc-reference.md`, either generate full sections or insert generated tables between stable markers.
+
+Definition of done:
+
+- A CI check fails when a registered GUC is missing from the docs.
+- A CI check fails when a documented default/type/context differs from code.
+- Deprecated or legacy names such as `trickle_integration` and `citus_trickle_compat` are documented as legacy without hiding that they remain active GUC names.
+
+### B2. Generate or Check the HTTP Endpoint Inventory
+
+`pg_ripple_http/src/routing/mod.rs` is the source of truth for HTTP routes. Build a small route extractor that emits method, path, handler, and auth expectation.
+
+Implementation steps:
+
+1. Parse Axum `.route(...)` declarations from `pg_ripple_http/src/routing/mod.rs`.
+2. Map handler functions to auth mode by scanning for `check_auth`, `check_auth_write`, metrics-token checks, or no check.
+3. Emit `target/docs/http-routes.json`.
+4. Compare it to the table in `docs/src/reference/http-api.md`.
+5. Add route documentation requirements for new handlers in PR review.
+
+Definition of done:
+
+- Every implemented route appears in `http-api.md`.
+- Method mismatches fail CI, such as documenting `POST` where the router uses `PUT`.
+- Auth labels are generated from the handler or explicitly overridden in a small allowlist.
+
+### B3. Generate SQL Function Coverage
+
+The SQL reference should be checked against pgrx exports.
+
+Implementation options:
+
+- Parse `#[pg_extern]` functions in `src/**/*.rs` and compare names to docs.
+- Prefer `cargo pgrx schema` output if it is reliable in CI, because it reflects actual SQL names and defaults after pgrx expansion.
+
+Minimum metadata per function:
+
+- SQL name and schema.
+- Argument names and defaults.
+- Return type.
+- Source file.
+- Docs page or section that owns it.
+- Stability tier: public, legacy alias, internal/admin, or deprecated.
+
+Definition of done:
+
+- Public SQL functions are either documented or intentionally marked internal.
+- Legacy aliases such as `trickle_available()` are documented as compatibility aliases.
+- The docs do not claim network I/O or background behavior for SQL functions that only record catalog state.
+
+### B4. Check Error Code Coverage
+
+Build a scanner for `PT[0-9]{3,4}` occurrences in Rust, SQL, tests, and docs.
+
+Definition of done:
+
+- Every user-facing error code emitted by code appears in `docs/src/reference/error-catalog.md` or `error-codes.md`.
+- Error docs include cause, likely fix, and owning subsystem.
+- Duplicate meanings for the same code fail CI.
+
+## 5. Workstream C: Truth Audit by Feature Area
+
+Run a page-by-page truth audit using the implementation as source of truth. Each feature page should have a small front-matter or first-section status block with:
+
+- Availability version.
+- Required extension(s), if any.
+- SQL entry points.
+- HTTP entry points, if any.
+- Degraded behavior when optional dependencies are absent.
+- Link to the relevant reference page.
+
+Audit order:
+
+1. Getting Started and Evaluate pages.
+2. Operations and deployment pages.
+3. SQL/API references.
+4. Feature deep dives.
+5. Cookbook recipes.
+6. AI/RAG pages.
+7. Research and historical pages.
+
+High-priority checks:
+
+- pg_tide vs pg_trickle responsibilities.
+- HTTP routes and auth modes.
+- GUC defaults and ranges.
+- JSON mapping writeback behavior.
+- Federation credential and SSRF policy behavior.
+- Rule-library federation SQL vs HTTP responsibilities.
+- Conformance claims and CI gate language.
+- Performance claims that imply a benchmark source.
+
+Definition of done:
+
+- Every feature page states optional dependencies accurately.
+- No page describes a function, endpoint, or GUC that does not exist.
+- Historical release notes remain historical and do not masquerade as current guidance.
+
+## 6. Workstream D: Executable Examples
+
+Examples are the highest-trust part of the docs and should be treated like tests.
+
+Implementation steps:
+
+1. Mark code blocks with one of these labels in nearby prose: executable, illustrative, or pseudo-output.
+2. Extract executable SQL blocks from Getting Started, core Feature pages, and Cookbook pages.
+3. Run them in a temporary pg_ripple database through `cargo pgrx regress` or a lightweight psql harness.
+4. Store expected outputs for short examples where stable.
+5. Skip examples requiring external services unless a mock or local fixture exists.
+
+Priority pages:
+
+- `docs/src/getting-started/hello-world.md`
+- `docs/src/getting-started/tutorial.md`
+- `docs/src/features/loading-data.md`
+- `docs/src/features/querying-with-sparql.md`
+- `docs/src/features/validating-data-quality.md`
+- `docs/src/features/reasoning-and-inference.md`
+- `docs/src/features/json-mapping.md`
+- `docs/src/reference/http-api.md`
+
+Definition of done:
+
+- Hello World SQL is regression-tested.
+- At least one executable example per major feature area runs in CI.
+- Examples that require pgvector, PostGIS, pg_tide, pg_trickle, Citus, or external LLM services are clearly labeled.
+
+## 7. Workstream E: Deduplication and Information Architecture
+
+Use the existing structure, but make page responsibilities explicit.
+
+Rules:
+
+- Feature pages explain concepts and primary workflows.
+- Reference pages enumerate exact APIs, signatures, GUCs, limits, and error codes.
+- Cookbook pages solve one concrete problem with minimal detours.
+- Operations pages describe deployment and failure modes.
+- Blog links provide background, not required operational steps.
+
+Known consolidation candidates:
+
+| Area | Current issue | Target shape |
+|---|---|---|
+| Live views, live subscriptions, CDC subscriptions | Three pages overlap but cover different APIs. | Keep all three, but add a comparison table and clear first paragraph on each page. |
+| Rule-library federation | Cookbook and guide overlapped. | Cookbook stays a short recipe; guide owns the full walkthrough. |
+| SQL API vs SQL function reference vs user-guide SQL reference | Multiple reference surfaces can disagree. | Establish one canonical generated SQL reference and make other pages task-oriented indexes. |
+| GUC docs | `docs/gucs.md` and `guc-reference.md` duplicate data. | Generate both from the same metadata or make one redirect to the other. |
+| Historical plans and gap analyses | Old docs describe obsolete version state. | Mark historical docs as superseded and keep current plans under `plans/`. |
+
+Definition of done:
+
+- A reader can tell why each similarly named page exists.
+- No cookbook page duplicates a guide page line-for-line.
+- Reference tables are not manually copied into multiple places without a generated source.
+
+## 8. Workstream F: Style and Consistency Pass
+
+Create a short `docs/STYLE.md` and apply it during page audits.
+
+Style rules:
+
+- Prefer direct, operational wording over release-note phrasing.
+- Put current behavior first; version history belongs in notes.
+- Use `pg_tide` only for relay/outbox/inbox transport.
+- Use `pg_trickle` only for IVM-backed views, ExtVP, SHACL DAG monitors, and live statistics where code requires it.
+- Spell SQL function names with `pg_ripple.` prefix on first mention.
+- Use `postgresql` or `sql` code fences consistently.
+- Use `Warning`, `Note`, and `Tip` callouts consistently through mdbook-admonish syntax.
+- Avoid promising exact performance unless a benchmark file or CI result is linked.
+
+Definition of done:
+
+- New docs PRs have a concise style checklist.
+- Existing high-traffic pages follow the style guide.
+- Generated reference pages are exempt from prose style except for intro sections.
+
+## 9. Workstream G: Release Process Integration
+
+Docs quality should be part of release readiness, not a cleanup after release.
+
+Add to the release checklist:
+
+1. Run `just docs-build`.
+2. Run `just docs-check-links`.
+3. Run `just docs-check-summary`.
+4. Run generated-reference drift checks for GUCs, SQL functions, HTTP routes, env vars, and error codes.
+5. Confirm `CHANGELOG.md` links to any new user-facing docs.
+6. Confirm new HTTP routes appear in `docs/src/reference/http-api.md`.
+7. Confirm new GUCs appear in `docs/src/reference/guc-reference.md`.
+8. Confirm new SQL functions appear in the SQL reference or are marked internal.
+9. Confirm any new migration script has upgrade docs if it changes user-visible schema.
+
+Definition of done:
+
+- Release PRs cannot merge with broken docs checks.
+- The changelog template includes a documentation checklist.
+- `plans/documentation-2.md` is updated or closed out as workstreams complete.
+
+## 10. Suggested Execution Order
+
+### Phase 1: Guardrails (1-2 days)
+
+- Add link checker.
+- Add SUMMARY coverage checker.
+- Add `just docs-build`.
+- Add CI job for docs checks.
+- Mark historical docs as superseded.
+
+### Phase 2: Generated Drift Checks (3-5 days)
+
+- Implement GUC metadata extractor.
+- Implement HTTP route extractor.
+- Implement environment-variable extractor for `pg_ripple_http`.
+- Add non-failing report mode first, then make new drift fail CI after the initial backlog is fixed.
+
+### Phase 3: High-Traffic Truth Audit (3-7 days)
+
+- Audit Getting Started and Evaluate pages.
+- Audit Operations pages for pg_tide/pg_trickle, Docker versions, compatibility, security, and deployment commands.
+- Audit `http-api.md`, `guc-reference.md`, and SQL references against generated reports.
+
+### Phase 4: Executable Examples (5-10 days)
+
+- Build SQL extraction harness.
+- Add tests for Hello World and the guided tutorial.
+- Add representative examples for SHACL, Datalog, JSON mapping, SPARQL Update, and export.
+
+### Phase 5: Deduplication and Polish (ongoing)
+
+- Consolidate overlapping pages.
+- Add comparison tables where similar APIs exist.
+- Normalize style and callouts.
+- Add per-page status/dependency blocks for feature pages.
+
+## 11. Acceptance Criteria for v1.0 Documentation
+
+Before v1.0.0, documentation should meet these criteria:
+
+- `mdbook build docs` succeeds in CI.
+- Link checker reports 0 missing local links.
+- SUMMARY checker reports 0 orphan pages and 0 accidental duplicate entries.
+- HTTP route checker reports 0 undocumented implemented routes.
+- GUC checker reports 0 missing public GUCs and 0 default/type/context mismatches.
+- SQL function checker reports 0 undocumented public functions, excluding approved internal/admin allowlist entries.
+- Error-code checker reports 0 undocumented user-facing PT codes.
+- Hello World and the guided tutorial examples run successfully in CI.
+- Optional dependency pages clearly distinguish pg_tide, pg_trickle, pgvector, PostGIS, Citus, and pg_ripple_http.
+- Historical analyses in `docs/` are clearly marked as historical or moved under `plans/archive/`.
+
+## 12. Open Questions
+
+- Should `docs/gucs.md` remain as a separate root-level artifact, or should it be generated from and linked to `docs/src/reference/guc-reference.md`?
+- Should top-level `blog/` posts be published into the mdBook, or should docs continue linking to the repository copy on GitHub?
+- Should `docs/book/` generated output be committed, or should CI publish it as a build artifact only?
+- Should the HTTP API table be generated directly into Markdown, or should generated OpenAPI become the canonical reference with Markdown summaries?
+- Should historical planning documents under `docs/` be moved to `plans/archive/` to keep `docs/` focused on user-facing documentation?

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+scripts/check_docs_links.py — A1 guardrail from plans/documentation-2.md
+
+Scans every Markdown file under docs/ and verifies that relative local links
+resolve to an existing file.
+
+Rules:
+  - Relative links that start with http/https/mailto are skipped (external).
+  - Fragment-only links (#anchor) are skipped.
+  - Links to files outside the docs tree that start with / are skipped.
+  - Links into top-level blog/, plans/, tests/, results/ are checked by
+    converting them to an absolute project path.
+  - Query strings are stripped from links before resolving.
+
+Exit code:  0  = all local links resolve
+            1  = missing files found or usage error
+
+Usage:
+    python3 scripts/check_docs_links.py [--root ROOT] [--verbose]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+class Finding(NamedTuple):
+    source_file: Path
+    line: int
+    raw_link: str
+    resolved: Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Check that relative Markdown links in docs/ resolve to real files."
+    )
+    p.add_argument(
+        "--root",
+        default=None,
+        metavar="DIR",
+        help="Project root (default: parent of this script).",
+    )
+    p.add_argument("--verbose", action="store_true", help="Print every checked link.")
+    return p.parse_args()
+
+
+# Match Markdown link targets: [text](target) or ![alt](target)
+_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+# Match reference-style link definitions: [id]: target
+_REF_RE = re.compile(r"^\s{0,3}\[[^\]]+\]:\s+(\S+)")
+
+
+def extract_links(text: str) -> list[tuple[int, str]]:
+    """Return (1-based line number, raw target) pairs for every link in *text*."""
+    results: list[tuple[int, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for m in _LINK_RE.finditer(line):
+            results.append((lineno, m.group(1)))
+        m2 = _REF_RE.match(line)
+        if m2:
+            results.append((lineno, m2.group(1)))
+    return results
+
+
+def is_external(target: str) -> bool:
+    return (
+        target.startswith(("http://", "https://", "mailto:", "ftp://"))
+        or target.startswith("#")
+        or target.startswith("//")
+    )
+
+
+def strip_fragment_and_query(target: str) -> str:
+    target = target.split("#")[0]
+    target = target.split("?")[0]
+    return target
+
+
+def resolve_link(source_file: Path, raw_target: str, root: Path) -> Path | None:
+    """
+    Resolve *raw_target* relative to *source_file*.
+
+    Returns the resolved Path, or None if the link cannot be checked (external).
+    """
+    if is_external(raw_target):
+        return None
+
+    clean = strip_fragment_and_query(raw_target)
+    if not clean:
+        # Fragment-only after stripping
+        return None
+
+    if clean.startswith("/"):
+        # Absolute path relative to root — skip; out of scope for local checks.
+        return None
+
+    resolved = (source_file.parent / clean).resolve()
+    return resolved
+
+
+def check_file(md_file: Path, root: Path, verbose: bool) -> list[Finding]:
+    text = md_file.read_text(encoding="utf-8", errors="replace")
+    links = extract_links(text)
+    missing: list[Finding] = []
+    for lineno, raw in links:
+        resolved = resolve_link(md_file, raw, root)
+        if resolved is None:
+            if verbose:
+                print(f"  SKIP  {raw}")
+            continue
+        if not resolved.exists():
+            missing.append(Finding(md_file, lineno, raw, resolved))
+            if verbose:
+                print(f"  MISS  {raw!r}  ->  {resolved}")
+        else:
+            if verbose:
+                print(f"  OK    {raw}")
+    return missing
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.root).resolve() if args.root else Path(__file__).parent.parent.resolve()
+    docs_dir = root / "docs"
+    if not docs_dir.is_dir():
+        print(f"ERROR: docs/ directory not found at {docs_dir}", file=sys.stderr)
+        return 1
+
+    all_missing: list[Finding] = []
+    md_files = sorted(docs_dir.rglob("*.md"))
+    # Exclude generated book output
+    md_files = [f for f in md_files if "docs/book" not in f.as_posix()]
+
+    for md_file in md_files:
+        if args.verbose:
+            print(f"\n=== {md_file.relative_to(root)} ===")
+        missing = check_file(md_file, root, args.verbose)
+        all_missing.extend(missing)
+
+    if all_missing:
+        print(f"\nmissing={len(all_missing)}")
+        for f in all_missing:
+            rel_src = f.source_file.relative_to(root)
+            rel_res = f.resolved.relative_to(root) if f.resolved.is_relative_to(root) else f.resolved
+            print(f"  {rel_src}:{f.line}: {f.raw_link!r}  ->  {rel_res}")
+        return 1
+
+    print(f"missing=0")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_docs_summary.py
+++ b/scripts/check_docs_summary.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+scripts/check_docs_summary.py — A2 guardrail from plans/documentation-2.md
+
+Verifies that every .md file under docs/src/ (except SUMMARY.md itself and
+any files listed in the allowlist) is referenced exactly once in SUMMARY.md.
+
+Exit code:  0  = no orphans, no duplicates
+            1  = orphans or duplicates found
+
+Allowlist:
+  Add filenames (relative to docs/src/) to ALLOWLIST below to suppress
+  warnings for intentionally hidden pages (e.g. partial drafts).
+
+Usage:
+    python3 scripts/check_docs_summary.py [--root ROOT] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+# Pages that are intentionally not in SUMMARY.md.
+# Add entries as relative paths from docs/src/, e.g. "drafts/wip.md".
+ALLOWLIST: frozenset[str] = frozenset(
+    [
+        # blog mirror pages are copied in by CI, not stored in the tree
+        # "blog/",
+    ]
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Check that all docs/src/ pages appear in SUMMARY.md.",
+    )
+    p.add_argument("--root", default=None, metavar="DIR")
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Also fail on duplicate SUMMARY.md entries (default: warn only).",
+    )
+    return p.parse_args()
+
+
+_LINK_RE = re.compile(r"\]\(([^)]+\.md)(?:#[^)]*)?\)")
+
+
+def extract_summary_links(summary_text: str) -> list[str]:
+    """Return all .md link targets from SUMMARY.md."""
+    return _LINK_RE.findall(summary_text)
+
+
+def main() -> int:
+    args = parse_args()
+    root = (
+        Path(args.root).resolve() if args.root else Path(__file__).parent.parent.resolve()
+    )
+    docs_src = root / "docs" / "src"
+    summary_path = docs_src / "SUMMARY.md"
+
+    if not summary_path.exists():
+        print(f"ERROR: {summary_path} not found", file=sys.stderr)
+        return 1
+
+    summary_text = summary_path.read_text(encoding="utf-8", errors="replace")
+    raw_links = extract_summary_links(summary_text)
+
+    # Normalise summary links to paths relative to docs/src/
+    summary_targets: list[Path] = []
+    for link in raw_links:
+        target = (summary_path.parent / link).resolve()
+        if target.is_relative_to(docs_src):
+            summary_targets.append(target.relative_to(docs_src))
+        # else: link points outside docs/src — skip
+
+    link_counts: Counter[Path] = Counter(summary_targets)
+
+    # Collect all .md files under docs/src/ (excluding SUMMARY.md and book output)
+    all_pages: list[Path] = []
+    for md in sorted(docs_src.rglob("*.md")):
+        rel = md.relative_to(docs_src)
+        if rel.parts[0] in ("SUMMARY.md",) or str(rel) == "SUMMARY.md":
+            continue
+        all_pages.append(rel)
+
+    # Filter allowlisted pages
+    checked_pages = [p for p in all_pages if str(p) not in ALLOWLIST]
+
+    orphans = [p for p in checked_pages if link_counts[p] == 0]
+    duplicates = [p for p, cnt in link_counts.items() if cnt > 1]
+
+    exit_code = 0
+
+    if orphans:
+        print(f"ORPHAN PAGES ({len(orphans)} not in SUMMARY.md):")
+        for p in sorted(orphans):
+            print(f"  {p}")
+        exit_code = 1
+
+    if duplicates:
+        msg = f"DUPLICATE ENTRIES ({len(duplicates)} pages linked more than once in SUMMARY.md):"
+        print(msg)
+        for p in sorted(duplicates):
+            print(f"  {p}  (×{link_counts[p]})")
+        if args.strict:
+            exit_code = 1
+        else:
+            print("  (pass --strict to fail on duplicates)")
+
+    if exit_code == 0:
+        print(f"orphans=0  (checked {len(checked_pages)} pages)")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_guc_drift.py
+++ b/scripts/check_guc_drift.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+scripts/check_guc_drift.py — B1 drift check from plans/documentation-2.md
+
+Extracts GUC static variable declarations from src/gucs/**/*.rs (the actual
+defaults held in GucSetting::new(…)) and compares them against the documented
+defaults in docs/gucs.md and docs/src/reference/guc-reference.md.
+
+What is checked:
+  1. Every GUC declared in Rust appears in at least one of the two doc files.
+  2. When a numeric/bool/string default is readable from the Rust source, it is
+     checked against the value shown in the doc files (non-blocking report mode
+     by default; use --strict to fail on mismatch).
+
+What is NOT checked (too fragile to parse reliably):
+  - GUCs whose default is a constant expression (e.g. MY_CONST as i32).
+  - Context and access-level claims.
+  - Ranges / enum members.
+
+Output modes:
+  --strict  Fail (exit 1) on missing GUCs or default mismatches.
+            Default is report-only (exit 0).
+
+Usage:
+    python3 scripts/check_guc_drift.py [--root ROOT] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# ─── Data model ─────────────────────────────────────────────────────────────
+
+@dataclass
+class GucDef:
+    name: str           # SQL name like "vp_promotion_threshold"
+    rust_default: Optional[str]   # extracted from GucSetting::new(…) or None
+    source_file: str
+    source_line: int
+
+
+# ─── Extraction ─────────────────────────────────────────────────────────────
+
+# Matches lines like:
+#   pub static FOO_BAR: pgrx::GucSetting<i32> = pgrx::GucSetting::<i32>::new(1000);
+# or multi-line with the ::new call on the next line.
+_STATIC_RE = re.compile(
+    r"pub\s+static\s+([A-Z_]+)\s*:",
+)
+_NEW_RE = re.compile(r"::new\(([^)]*)\)")
+
+
+def extract_gucs(src_dir: Path) -> list[GucDef]:
+    """
+    Walk src/gucs/**/*.rs and extract GUC static names + their ::new defaults.
+    Also reads src/gucs/registration/**/*.rs to find the SQL name mapping.
+    """
+    gucs: list[GucDef] = []
+
+    for rs_file in sorted(src_dir.rglob("*.rs")):
+        lines = rs_file.read_text(encoding="utf-8", errors="replace").splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            m_static = _STATIC_RE.search(line)
+            if m_static:
+                rust_var = m_static.group(1)
+                # Try to find ::new on the same line or next few lines
+                default_val: Optional[str] = None
+                search_window = "\n".join(lines[i : i + 5])
+                m_new = _NEW_RE.search(search_window)
+                if m_new:
+                    raw = m_new.group(1).strip()
+                    # Skip complex expressions
+                    if re.match(r'^(true|false|-?\d[\d_]*|"[^"]*"|None)$', raw):
+                        default_val = raw.replace("_", "")
+                gucs.append(
+                    GucDef(
+                        name=rust_var.lower(),
+                        rust_default=default_val,
+                        source_file=str(rs_file.relative_to(src_dir.parent)),
+                        source_line=i + 1,
+                    )
+                )
+            i += 1
+
+    # Also walk registration files for register_guc calls to get SQL names
+    # (the static Rust name is ALL_CAPS; SQL name is pg_ripple.<lower_name>)
+    return gucs
+
+
+# ─── Doc scanning ────────────────────────────────────────────────────────────
+
+def load_doc_corpus(root: Path) -> str:
+    parts: list[str] = []
+    for path in [
+        root / "docs" / "gucs.md",
+        root / "docs" / "src" / "reference" / "guc-reference.md",
+    ]:
+        if path.exists():
+            parts.append(path.read_text(encoding="utf-8", errors="replace"))
+    return "\n".join(parts)
+
+
+# ─── Comparison ─────────────────────────────────────────────────────────────
+
+def normalise_default(val: str) -> str:
+    """Normalise a default string for comparison."""
+    val = val.strip().lower().strip("'\"")
+    # Normalise boolean synonyms
+    if val in ("on", "true", "1", "yes"):
+        return "on"
+    if val in ("off", "false", "0", "no"):
+        return "off"
+    # Normalise null/none synonyms
+    if val in ("none", "null", "(none)", "(null)", ""):
+        return "null"
+    return val
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Check GUC defaults against documentation.")
+    ap.add_argument("--root", default=None, metavar="DIR")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 on missing GUCs or default mismatches.",
+    )
+    args = ap.parse_args()
+
+    root = (
+        Path(args.root).resolve() if args.root else Path(__file__).parent.parent.resolve()
+    )
+    gucs_dir = root / "src" / "gucs"
+    if not gucs_dir.is_dir():
+        print(f"ERROR: {gucs_dir} not found", file=sys.stderr)
+        return 1
+
+    gucs = extract_gucs(gucs_dir)
+    if not gucs:
+        print("WARNING: no GUC statics found in src/gucs/ — check the extractor.")
+        return 0
+
+    corpus = load_doc_corpus(root)
+    if not corpus:
+        print("ERROR: could not load GUC doc files.", file=sys.stderr)
+        return 1
+
+    missing: list[GucDef] = []
+    mismatch: list[tuple[GucDef, str]] = []
+
+    for guc in gucs:
+        sql_name = guc.name  # lower snake_case
+
+        # Check presence: either the static var name (lower) or pg_ripple.name appears
+        appears = (
+            sql_name in corpus
+            or f"pg_ripple.{sql_name}" in corpus
+            or f"`{sql_name}`" in corpus
+        )
+        if not appears:
+            missing.append(guc)
+            continue
+
+        # Check default value when extractable
+        if guc.rust_default is None:
+            continue
+
+        rust_norm = normalise_default(guc.rust_default)
+
+        # Look for documented defaults near the GUC name.
+        # Pattern: table cell or backtick-quoted value near the name.
+        pattern = re.compile(
+            rf"`{re.escape(sql_name)}`[^|]*\|[^|]*\|\s*`?([^`|\n]+?)`?\s*\|",
+            re.IGNORECASE,
+        )
+        doc_defaults = pattern.findall(corpus)
+        if doc_defaults:
+            doc_norm = normalise_default(doc_defaults[0])
+            if rust_norm != doc_norm:
+                mismatch.append((guc, doc_norm))
+
+    exit_code = 0
+
+    if missing:
+        print(f"\nMISSING FROM DOCS ({len(missing)} GUCs):")
+        for g in missing:
+            print(f"  {g.name:40s}  {g.source_file}:{g.source_line}")
+        if args.strict:
+            exit_code = 1
+        else:
+            print("  (pass --strict to fail on missing GUCs)")
+
+    if mismatch:
+        print(f"\nDEFAULT MISMATCH ({len(mismatch)} GUCs):")
+        for g, doc_val in mismatch:
+            print(
+                f"  {g.name:40s}  rust={g.rust_default!r}  docs={doc_val!r}  "
+                f"({g.source_file}:{g.source_line})"
+            )
+        if args.strict:
+            exit_code = 1
+        else:
+            print("  (pass --strict to fail on default mismatches)")
+
+    if not missing and not mismatch:
+        print(f"OK: checked {len(gucs)} GUC statics — all present in docs, no default mismatches detected.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_http_routes.py
+++ b/scripts/check_http_routes.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+scripts/check_http_routes.py — B2 drift check from plans/documentation-2.md
+
+Extracts HTTP routes from pg_ripple_http/src/routing/mod.rs and compares them
+against the endpoint table in docs/src/reference/http-api.md.
+
+What is checked:
+  1. Every .route(…) path in the router appears in the docs table.
+  2. Methods declared in the router match what is documented.
+
+Output modes:
+  --strict  Fail (exit 1) on undocumented routes or method mismatches.
+            Default is report-only (exit 0).
+
+Usage:
+    python3 scripts/check_http_routes.py [--root ROOT] [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class Route:
+    path: str
+    methods: list[str]
+    source_line: int
+
+
+# Matches: .route("/some/path", get(handler).post(other))
+_ROUTE_LINE_RE = re.compile(r'\.route\(\s*"([^"]+)"')
+# Matches HTTP method calls: get(…), post(…), put(…), delete(…), patch(…)
+_METHOD_RE = re.compile(r'\b(get|post|put|delete|patch|head|options)\s*\(')
+
+# Axum path params {param} or :param → normalised to {param}
+_PATH_PARAM_RE = re.compile(r':[a-z_]+')
+
+
+def normalise_path(path: str) -> str:
+    """Normalise Axum path to the form used in docs (curly braces, no trailing slash)."""
+    path = _PATH_PARAM_RE.sub(lambda m: '{' + m.group(0)[1:] + '}', path)
+    return path.rstrip("/")
+
+
+def extract_routes(router_path: Path) -> list[Route]:
+    """Parse .route(…) declarations from the Axum router file."""
+    text = router_path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    routes: list[Route] = []
+
+    i = 0
+    while i < len(lines):
+        m = _ROUTE_LINE_RE.search(lines[i])
+        if m:
+            raw_path = m.group(1)
+            # Collect method calls: may span several lines until the closing )
+            window = []
+            depth = 0
+            j = i
+            while j < min(i + 12, len(lines)):
+                window.append(lines[j])
+                depth += lines[j].count("(") - lines[j].count(")")
+                if depth <= 0 and j > i:
+                    break
+                j += 1
+            window_text = " ".join(window)
+            methods = sorted(set(m.upper() for m in _METHOD_RE.findall(window_text)))
+            routes.append(Route(
+                path=normalise_path(raw_path),
+                methods=methods or ["GET"],
+                source_line=i + 1,
+            ))
+        i += 1
+
+    return routes
+
+
+def load_docs_table(http_api_path: Path) -> str:
+    """Load the endpoint table from http-api.md as a raw string."""
+    if not http_api_path.exists():
+        return ""
+    return http_api_path.read_text(encoding="utf-8", errors="replace")
+
+
+def path_in_docs(path: str, docs_text: str) -> bool:
+    """Return True if the route path appears anywhere in the docs."""
+    # Exact string match (backtick-quoted in table cells)
+    escaped = re.escape(path)
+    return bool(re.search(escaped, docs_text))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Check HTTP routes in routing/mod.rs against docs."
+    )
+    ap.add_argument("--root", default=None, metavar="DIR")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 on undocumented routes.",
+    )
+    args = ap.parse_args()
+
+    root = (
+        Path(args.root).resolve() if args.root else Path(__file__).parent.parent.resolve()
+    )
+
+    router_path = root / "pg_ripple_http" / "src" / "routing" / "mod.rs"
+    if not router_path.exists():
+        print(f"ERROR: router file not found at {router_path}", file=sys.stderr)
+        return 1
+
+    http_api_path = root / "docs" / "src" / "reference" / "http-api.md"
+
+    routes = extract_routes(router_path)
+    docs_text = load_docs_table(http_api_path)
+
+    if not routes:
+        print("WARNING: no .route(…) declarations found in router file.")
+        return 0
+
+    undocumented: list[Route] = []
+    for route in routes:
+        if not path_in_docs(route.path, docs_text):
+            undocumented.append(route)
+
+    exit_code = 0
+
+    if undocumented:
+        print(f"\nUNDOCUMENTED ROUTES ({len(undocumented)}):")
+        for r in undocumented:
+            print(
+                f"  {', '.join(r.methods):20s}  {r.path:50s}  "
+                f"(routing/mod.rs:{r.source_line})"
+            )
+        if args.strict:
+            exit_code = 1
+        else:
+            print("  (pass --strict to fail on undocumented routes)")
+
+    if not undocumented:
+        print(
+            f"OK: checked {len(routes)} routes — all paths appear in http-api.md."
+        )
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# docs: implement documentation-2.md quality plan

Implements the plan written in `plans/documentation-2.md`.

---

## What changed

### Phase 1 — Guardrails (Workstreams A1–A3)

| Item | File | Purpose |
|---|---|---|
| Local link checker | `scripts/check_docs_links.py` | Exits 1 on any broken relative link in docs/; gate is `missing=0` |
| SUMMARY coverage check | `scripts/check_docs_summary.py` | Exits 1 when a page under docs/src/ is not in SUMMARY.md; gate is `orphans=0` |
| CI workflow | `.github/workflows/docs-check.yml` | Runs all four checks on every PR touching docs, routing, or GUC sources |
| justfile docs group | `justfile` | `just docs-build`, `just docs-check-links`, `just docs-check-summary`, `just docs-check-guc-drift`, `just docs-check-http-routes`, `just docs-check` |

### Phase 2 — Generated drift checks (Workstreams B1–B2)

| Item | File | Purpose |
|---|---|---|
| GUC drift checker | `scripts/check_guc_drift.py` | Extracts GUC statics from `src/gucs/**/*.rs` and compares defaults against `docs/gucs.md` and `guc-reference.md` (report-only in CI until backlog is zero) |
| HTTP route checker | `scripts/check_http_routes.py` | Extracts `.route(…)` declarations from `pg_ripple_http/src/routing/mod.rs` and verifies all paths appear in `http-api.md` (report-only; 31 routes, 0 missing) |

### Workstream F — Style guide

- `docs/STYLE.md`: new docs style guide covering pg_tide vs pg_trickle naming, page-type responsibilities, code-block labels (`executable`, `illustrative`, `pseudo-output`), callout conventions, optional-dependency table format, and a PR checklist.

### Workstream G — Release process

- `RELEASE.md`: added documentation validation step (`just docs-check` + `mdbook build docs`) to the release checklist, before tagging.

### GUC default fixes (docs/gucs.md)

The `check_guc_drift.py` script found 17 stale default values. All corrected against `src/gucs/storage.rs`:

| GUC | Old doc default | Correct default |
|---|---|---|
| `replication_batch_size` | 500 | 100 |
| `replication_batch_interval_ms` | 200 | 500 |
| `vp_promotion_batch_size` | 500 | 10 000 |
| `dict_vacuum_threshold` | 50 000 | 10 000 |
| `describe_max_depth` | 3 | 16 |
| `cdc_watermark_batch_size` | 1 000 | 100 |
| `cdc_watermark_flush_interval_ms` | 500 | 50 |
| `temporal_cdc_enabled` | off | on |
| `citus_service_pruning` | on | off |
| `dedup_on_merge` | on | off |
| `tombstone_retention_seconds` | 3 600 | 0 |
| `stats_scan_limit` | 10 000 | 1 000 |
| `vacuum_dict_batch_size` | 1 000 | 200 |
| `export_batch_size` | 1 000 | 10 000 |
| `columnar_threshold` | 100 000 | -1 (disabled) |
| `adaptive_indexing_enabled` | on | off |
| `cdc_bridge_flush_ms` | 100 | 200 |

### Previously committed docs audit (same branch)

42 source-file edits carried over from the audit session:
- Broken local links fixed (was 47 missing, now 0).
- `docs/book.toml`: `mdbook-admonish` marked optional.
- `docs/src/reference/http-api.md`: full endpoint inventory, JSON mapping writeback section added.
- `docs/src/reference/guc-reference.md`: GUC context labels corrected.
- pg_tide vs pg_trickle wording corrected on operations and feature pages.
- Rule-library federation cookbook rewritten as a short recipe (guide is the canonical walkthrough).
- `shacl-sparql-rules.md`: `sh:SPARQLRule` documented as implemented (v0.79.0).
- `docs/GAP_ANALYSIS.md`, `docs/IMPROVEMENT_PLAN.md`: historical banners added.
- `plans/documentation-2.md`: detailed improvement plan created.

---

## Validation

All three hard-gate checks pass locally:

```
python3 scripts/check_docs_links.py   → missing=0
python3 scripts/check_docs_summary.py → orphans=0  (177 pages)
python3 scripts/check_http_routes.py  → OK: 31 routes checked, 0 missing
mdbook build docs                     → INFO HTML book written (admonish optional warning only)
```

The GUC drift and HTTP route drift checks run in report-only mode in CI. Switch both to `--strict` after the remaining backlog in their respective workstreams is closed.

---

## Checklist

- [x] `just docs-check-links` exits 0
- [x] `just docs-check-summary` exits 0
- [x] `just docs-check-http-routes` exits 0
- [x] `mdbook build docs` succeeds
- [x] No new broken links introduced
- [x] `git diff --check` clean
