### PR TITLE
fix(datalog): bind GRAPH ?g head column from var_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ Versions correspond to the milestones in [ROADMAP.md](ROADMAP.md).
 
 ### Fixed
 
+- **SHACL `sh:in` never matched a literal value set** — The single-triple write
+  guard resolved each declared value with `lookup_iri()`, which returns `NULL`
+  for a quoted literal. The allowed-value list was therefore empty for every
+  literal enumeration and every value was rejected. Comparison now uses the
+  canonical term form, so a plain literal and the same literal typed
+  `^^xsd:string` match (RDF 1.1), and a language tag compares case-insensitively.
+  The same fix applies to `sh:in` and `sh:hasValue` in the full-graph validator.
+  Observed in production: a seven-value `entityType` enumeration rejected all
+  seven of its own values.
+
+- **SHACL `sh:maxCount` counted the triple being validated twice in async mode** —
+  The guard added 1 to a value count taken *after* the write, so every
+  single-valued predicate reported `found 1 existing value(s), limit is 1`. It
+  also treated re-asserting an existing value as adding a second one. The guard
+  now checks whether the triple is already stored and only counts what the write
+  would actually add; `sh:qualifiedMaxCount` gets the same treatment. Value
+  counts are now `COUNT(DISTINCT o)`, matching SHACL's set semantics.
+  Together these two defects produced 18k dead letters in two days in a
+  production database, none of them a real data problem.
+
+- **Dead letter rows did not say which shape or constraint failed** — Async
+  validation wrote `"shapeIRI": "unknown"` with no path and no constraint name,
+  leaving `idx_dead_letter_shape` and `violation_summary` nothing to group by.
+  The write guard now returns a structured violation (shape IRI, path,
+  constraint) and the queue records all three.
+
+- **DICT-SUBXACT-02: subtransaction rollback left a phantom id in the
+  shared-memory dictionary cache** — Transaction abort evicted the entries
+  interned by that transaction; subtransaction abort did not. Because every
+  PL/pgSQL `EXCEPTION` block and every `SAVEPOINT` runs in a subtransaction, a
+  function that interned a term and then failed left the hash→id mapping live in
+  shared memory — cluster-wide, visible to every backend — while the dictionary
+  row was rolled back. The next write of that term took the cached id, skipped
+  the `INSERT`, and stored a triple pointing at a row that does not exist: no
+  error, no warning, undecodable data. Cache entries are now tagged with the
+  `SubTransactionId` that created them, evicted on `SUBXACT_EVENT_ABORT_SUB`,
+  and reassigned to the parent on `SUBXACT_EVENT_COMMIT_SUB`.
+
 - **CI: CloudNativePG extension image publishing** — Added `docker-cnpg` job to
   release workflow to build and publish the extension volume image with the
   `-cnpg` suffix on each tagged release. The `docker/Dockerfile.cnpg` existed
@@ -18,6 +56,21 @@ Versions correspond to the milestones in [ROADMAP.md](ROADMAP.md).
   ghcr.io/trickle-labs/pg-ripple:<version>-cnpg` to fail with "not found". Now
   the extension image is published automatically alongside the main extension
   and HTTP companion images.
+
+### Added
+
+- **`tests/pg_regress/shacl_write_guard`** — pins the write guard: a value inside
+  the `sh:in` set is accepted, re-asserting it is a no-op, a second distinct
+  value is rejected under `maxCount 1`, a conforming write validated after the
+  fact produces no dead letter, and a real violation records shape, constraint
+  and path.
+
+- **`tests/pg_regress/dict_subxact_phantom`** — pins the dictionary invariant
+  across `EXCEPTION` blocks, `ROLLBACK TO SAVEPOINT`, and a released savepoint
+  inside an aborting transaction: no stored triple may point at a missing
+  dictionary row. Note that the shared-memory cache only exists when pg_ripple
+  is in `shared_preload_libraries`; without preload the test passes for the wrong
+  reason.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versions correspond to the milestones in [ROADMAP.md](ROADMAP.md).
 
 ### Fixed
 
+- **`drain_dead_letter_queue()` deleted one row, not the queue.** It used
+  `Spi::get_one` on `DELETE … RETURNING 1`; `get_one` asks SPI for a single row and
+  SPI stops executing the command once the limit is reached, so exactly one row was
+  deleted while the function returned 1 as if it had emptied the queue. Observed in
+  production on 2026-07-28: the queue held 18 450 rows, the call returned 1, and the
+  next count still said 18 450. Every other DML in the module already used the
+  correct `WITH d AS (DELETE … RETURNING 1) SELECT count(*) FROM d` shape; this was
+  the only call outside the pattern. Pinned by
+  `tests/pg_regress/dead_letter_drain`.
+
 - **SHACL `sh:in` never matched a literal value set** — The single-triple write
   guard resolved each declared value with `lookup_iri()`, which returns `NULL`
   for a quoted literal. The allowed-value list was therefore empty for every
@@ -64,6 +74,9 @@ Versions correspond to the milestones in [ROADMAP.md](ROADMAP.md).
   value is rejected under `maxCount 1`, a conforming write validated after the
   fact produces no dead letter, and a real violation records shape, constraint
   and path.
+
+- **`tests/pg_regress/pgturbohybrid_bm25_bulk_delete`** — (in the pgturbohybrid repo)
+  see that project's changelog.
 
 - **`tests/pg_regress/dict_subxact_phantom`** — pins the dictionary invariant
   across `EXCEPTION` blocks, `ROLLBACK TO SAVEPOINT`, and a released savepoint

--- a/src/data_ops.rs
+++ b/src/data_ops.rs
@@ -247,9 +247,24 @@ mod pg_ripple {
     /// Returns the number of rows deleted.
     #[pg_extern]
     fn drain_dead_letter_queue() -> i64 {
-        pgrx::Spi::get_one::<i64>("DELETE FROM _pg_ripple.dead_letter_queue RETURNING 1")
-            .unwrap_or(None)
-            .unwrap_or(0)
+        // `Spi::get_one` sobre `DELETE ... RETURNING` apaga **uma** linha.
+        //
+        // O `get_one` pede uma linha ao SPI, e o SPI para de executar o comando
+        // quando o limite é atingido — num `DELETE ... RETURNING 1` isso significa
+        // uma linha apagada, com a função devolvendo 1 como se tivesse esvaziado a
+        // fila. Observado em produção em 28/07/2026: a fila tinha 18.450 linhas,
+        // `drain_dead_letter_queue()` devolveu 1, e a contagem seguinte ainda dizia
+        // 18.450.
+        //
+        // O resto do módulo já usa a forma certa — `WITH d AS (DELETE ... RETURNING
+        // 1) SELECT count(*) FROM d`, que executa o comando inteiro e conta depois.
+        // Esta era a única chamada fora do padrão.
+        pgrx::Spi::get_one::<i64>(
+            "WITH d AS (DELETE FROM _pg_ripple.dead_letter_queue RETURNING 1) \
+             SELECT count(*)::bigint FROM d",
+        )
+        .unwrap_or(None)
+        .unwrap_or(0)
     }
 
     // ── Deduplication functions (v0.7.0) ──────────────────────────────────────

--- a/src/datalog/compiler/helpers.rs
+++ b/src/datalog/compiler/helpers.rs
@@ -92,3 +92,15 @@ pub(crate) fn arith_op_sql(op: &ArithOp) -> &'static str {
         ArithOp::Div => "/",
     }
 }
+
+/// SQL expression for the head graph column (constant, default graph, or bound ?g).
+pub(crate) fn head_g_select_expr(head: &Atom, var_map: &VarMap) -> Result<String, String> {
+    Ok(match &head.g {
+        Term::Var(v) => var_map
+            .col_ref(v)
+            .ok_or_else(|| format!("unbound variable ?{v} in head graph"))?,
+        Term::Const(id) => const_sql(*id),
+        Term::DefaultGraph => "0".to_owned(),
+        Term::Wildcard => "0".to_owned(),
+    })
+}

--- a/src/datalog/compiler/mod.rs
+++ b/src/datalog/compiler/mod.rs
@@ -544,7 +544,7 @@ pub(super) fn is_recursive_rule(rule: &Rule, head_pred: i64) -> bool {
 fn compile_nonrecursive_rule(
     rule: &Rule,
     _head_pred: i64,
-    head_g_expr: &str,
+    _head_g_expr: &str,
     target: &str,
 ) -> Result<String, String> {
     let head = rule
@@ -956,6 +956,7 @@ fn compile_nonrecursive_rule(
         Term::Wildcard => return Err("wildcard in head not allowed".to_owned()),
         Term::DefaultGraph => "0".to_owned(),
     };
+    let select_g = helpers::head_g_select_expr(head, &var_map)?;
 
     let from_str = from_clauses.join("\n");
     let where_str = if where_clauses.is_empty() {
@@ -966,7 +967,7 @@ fn compile_nonrecursive_rule(
 
     Ok(format!(
         "INSERT INTO {target} (s, o, g)\n\
-         SELECT {select_s}, {select_o}, {head_g_expr}\n\
+         SELECT {select_s}, {select_o}, {select_g}\n\
          FROM {from_str}\n\
          {where_str}\n\
          ON CONFLICT DO NOTHING"
@@ -979,5 +980,6 @@ fn compile_nonrecursive_rule(
 // v0.122.0 H17-02: helpers extracted to helpers.rs
 pub(super) mod helpers;
 pub(crate) use helpers::{
-    arith_op_sql, build_join_cond, build_not_exists_conds, compare_op_sql, render_comparison_term,
+    arith_op_sql, build_join_cond, build_not_exists_conds, compare_op_sql, head_g_select_expr,
+    render_comparison_term,
 };

--- a/src/datalog/compiler/sql.rs
+++ b/src/datalog/compiler/sql.rs
@@ -5,7 +5,7 @@ use crate::datalog::{AggFunc, AggregateLiteral, Atom, BodyLiteral, Rule, StringB
 
 use super::{
     VarMap, arith_op_sql, build_join_cond, build_not_exists_conds, compare_op_sql, const_sql,
-    is_recursive_rule, render_comparison_term, vp_read_expr, vp_table,
+    head_g_select_expr, is_recursive_rule, render_comparison_term, vp_read_expr, vp_table,
 };
 
 pub(super) fn compile_recursive_rule(
@@ -474,7 +474,7 @@ pub fn compile_rule_delta_variants_to(
 fn compile_rule_with_one_delta_atom(
     rule: &Rule,
     _head_pred: i64,
-    head_g_expr: &str,
+    _head_g_expr: &str,
     target: &str,
     delta_atom_pos: usize,
     delta_table_name: &dyn Fn(i64) -> String,
@@ -670,6 +670,7 @@ fn compile_rule_with_one_delta_atom(
         Term::Const(id) => const_sql(*id),
         _ => return Err("wildcard/invalid in head not allowed".to_owned()),
     };
+    let select_g = head_g_select_expr(head, &var_map)?;
 
     let from_str = from_clauses.join("\n");
     let where_str = if where_clauses.is_empty() {
@@ -680,7 +681,7 @@ fn compile_rule_with_one_delta_atom(
 
     Ok(format!(
         "INSERT INTO {target} (s, o, g)\n\
-         SELECT {select_s}, {select_o}, {head_g_expr}\n\
+         SELECT {select_s}, {select_o}, {select_g}\n\
          FROM {from_str}\n\
          {where_str}\n\
          ON CONFLICT DO NOTHING"

--- a/src/dictionary/mod.rs
+++ b/src/dictionary/mod.rs
@@ -88,7 +88,15 @@ thread_local! {
     /// are evicted from shmem so that stale hash→id mappings cannot poison
     /// subsequent transactions (the dictionary rows are rolled back but the
     /// shmem entries would otherwise persist indefinitely).
-    static TX_SHMEM_INSERTS: RefCell<Vec<u128>> = const { RefCell::new(Vec::new()) };
+    ///
+    /// DICT-SUBXACT-02: cada entrada guarda também o `SubTransactionId` em que
+    /// foi criada. Sem isso, o rollback de uma subtransação (`SAVEPOINT`, ou o
+    /// bloco `EXCEPTION` de qualquer função PL/pgSQL) desfazia a linha do
+    /// dicionário e deixava o mapeamento hash→id vivo na memória compartilhada,
+    /// visível para todos os processos. A próxima escrita do mesmo termo pegava
+    /// o id fantasma do cache e gravava uma tripla apontando para uma linha que
+    /// não existe — dado indecifrável, sem erro nenhum.
+    static TX_SHMEM_INSERTS: RefCell<Vec<(u32, u128)>> = const { RefCell::new(Vec::new()) };
     /// Decode cache: sequence id → term value.
     static DECODE_CACHE: RefCell<LruCache<i64, String>> = RefCell::new(
         // SAFETY: CACHE_CAPACITY is a compile-time non-zero literal (4096).
@@ -190,7 +198,7 @@ fn encode_inner(term: &str, kind: i16) -> i64 {
 
     // Populate both caches.
     crate::shmem::encode_cache_insert(hash128, id);
-    TX_SHMEM_INSERTS.with(|v| v.borrow_mut().push(hash128));
+    track_shmem_insert(hash128);
     ENCODE_CACHE.with(|c| c.borrow_mut().put(hash128, id));
     DECODE_CACHE.with(|c| c.borrow_mut().put(id, term.to_owned()));
 
@@ -265,7 +273,7 @@ pub fn encode_typed_literal(value: &str, datatype: &str) -> i64 {
     .unwrap_or_else(|| pgrx::error!("dictionary encode_typed_literal: no id returned"));
 
     crate::shmem::encode_cache_insert(hash128, id);
-    TX_SHMEM_INSERTS.with(|v| v.borrow_mut().push(hash128));
+    track_shmem_insert(hash128);
     ENCODE_CACHE.with(|c| c.borrow_mut().put(hash128, id));
     DECODE_CACHE.with(|c| c.borrow_mut().put(id, canonical));
 
@@ -313,7 +321,7 @@ pub fn encode_lang_literal(value: &str, lang: &str) -> i64 {
     .unwrap_or_else(|| pgrx::error!("dictionary encode_lang_literal: no id returned"));
 
     crate::shmem::encode_cache_insert(hash128, id);
-    TX_SHMEM_INSERTS.with(|v| v.borrow_mut().push(hash128));
+    track_shmem_insert(hash128);
     ENCODE_CACHE.with(|c| c.borrow_mut().put(hash128, id));
     DECODE_CACHE.with(|c| c.borrow_mut().put(id, canonical));
 
@@ -449,7 +457,7 @@ pub fn encode_batch(terms_and_kinds: &[(&str, i16)]) -> Vec<i64> {
             )
         });
         crate::shmem::encode_cache_insert(hash, id);
-        TX_SHMEM_INSERTS.with(|v| v.borrow_mut().push(hash));
+        track_shmem_insert(hash);
         ENCODE_CACHE.with(|c| c.borrow_mut().put(hash, id));
         let term = terms_and_kinds[i].0;
         DECODE_CACHE.with(|c| c.borrow_mut().put(id, term.to_owned()));
@@ -562,7 +570,7 @@ pub fn encode_quoted_triple(s_id: i64, p_id: i64, o_id: i64) -> i64 {
     .unwrap_or_else(|| pgrx::error!("dictionary encode_quoted_triple: no id returned"));
 
     crate::shmem::encode_cache_insert(hash128, id);
-    TX_SHMEM_INSERTS.with(|v| v.borrow_mut().push(hash128));
+    track_shmem_insert(hash128);
     ENCODE_CACHE.with(|c| c.borrow_mut().put(hash128, id));
     DECODE_CACHE.with(|c| c.borrow_mut().put(id, canonical));
     id
@@ -869,7 +877,7 @@ pub fn decode(id: i64) -> Option<String> {
 pub(crate) fn clear_caches() {
     // Evict shmem entries that were inserted in this (now-aborting) transaction.
     TX_SHMEM_INSERTS.with(|v| {
-        for &hash128 in v.borrow().iter() {
+        for &(_subid, hash128) in v.borrow().iter() {
             crate::shmem::encode_cache_evict(hash128);
         }
         v.borrow_mut().clear();
@@ -879,6 +887,49 @@ pub(crate) fn clear_caches() {
     });
     DECODE_CACHE.with(|c| {
         c.borrow_mut().clear();
+    });
+}
+
+/// Anota que este termo acabou de entrar no cache de memória compartilhada,
+/// junto com a subtransação corrente, para poder ser desfeito no rollback certo.
+fn track_shmem_insert(hash128: u128) {
+    // SAFETY: encode só é chamado dentro de uma transação, onde
+    // GetCurrentSubTransactionId() é válido; a função não aloca nem faz SPI.
+    let subid = unsafe { pgrx::pg_sys::GetCurrentSubTransactionId() };
+    TX_SHMEM_INSERTS.with(|v| v.borrow_mut().push((subid, hash128)));
+}
+
+/// Desfaz no cache compartilhado o que a subtransação `my_subid` internou.
+///
+/// DICT-SUBXACT-02: chamado em `SUBXACT_EVENT_ABORT_SUB`. O corte é
+/// `subid >= my_subid` porque `SubTransactionId` cresce dentro da transação:
+/// qualquer subtransação aberta depois desta já morreu junto com ela.
+pub(crate) fn subxact_abort(my_subid: u32) {
+    TX_SHMEM_INSERTS.with(|v| {
+        let mut lista = v.borrow_mut();
+        lista.retain(|&(subid, hash128)| {
+            if subid >= my_subid {
+                crate::shmem::encode_cache_evict(hash128);
+                false
+            } else {
+                true
+            }
+        });
+    });
+}
+
+/// Passa para a subtransação pai o que a subtransação `my_subid` internou.
+///
+/// Sem isso, um `SAVEPOINT` bem-sucedido dentro de uma transação que depois
+/// aborta deixaria os termos daquele savepoint sem ninguém para desfazê-los —
+/// o mesmo fantasma, um nível acima.
+pub(crate) fn subxact_commit(my_subid: u32, parent_subid: u32) {
+    TX_SHMEM_INSERTS.with(|v| {
+        for entrada in v.borrow_mut().iter_mut() {
+            if entrada.0 >= my_subid {
+                entrada.0 = parent_subid;
+            }
+        }
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,15 @@ unsafe extern "C-unwind" fn sub_xact_callback_c(
         // so that stale id→string mappings from the aborted subtransaction
         // cannot be returned by subsequent decode() calls.
         crate::dictionary::invalidate_decode_cache();
+        // DICT-SUBXACT-02: e desfazer no cache de memória compartilhada os
+        // termos internados por esta subtransação. O cache é do cluster, não do
+        // processo: deixar o mapeamento vivo aqui fazia a próxima escrita de
+        // qualquer processo gravar tripla apontando para linha inexistente.
+        crate::dictionary::subxact_abort(_mySubid);
+    } else if event == pgrx::pg_sys::SubXactEvent::SUBXACT_EVENT_COMMIT_SUB {
+        // Subtransação boa: quem responde pelos termos dela passa a ser o pai,
+        // que ainda pode abortar.
+        crate::dictionary::subxact_commit(_mySubid, _parentSubid);
     }
 }
 

--- a/src/shacl/constraints/mod.rs
+++ b/src/shacl/constraints/mod.rs
@@ -36,6 +36,6 @@ pub struct ConstraintArgs<'a> {
 pub use super::Violation;
 pub(crate) use super::node_conforms_to_shape;
 pub(crate) use super::{
-    compare_dictionary_values, encode_shacl_in_value, get_language_tag, get_value_ids,
+    compare_dictionary_values, get_language_tag, get_value_ids, shacl_value_matches,
     value_has_datatype, value_has_node_kind, value_has_rdf_type,
 };

--- a/src/shacl/constraints/shape_based.rs
+++ b/src/shacl/constraints/shape_based.rs
@@ -1,35 +1,41 @@
 //! sh:in, sh:hasValue, sh:lessThan, sh:greaterThan, sh:closed constraint checkers.
 
 use super::{
-    ConstraintArgs, Violation, compare_dictionary_values, encode_shacl_in_value, get_value_ids,
+    ConstraintArgs, Violation, compare_dictionary_values, get_value_ids, shacl_value_matches,
 };
 
 /// Check `sh:in [values]` — every value node must be one of the allowed values.
+///
+/// A comparação é por forma canônica do termo, não por id do dicionário. Casar
+/// só por id fazia todo `sh:in` de literal falhar: a forma declarada na shape
+/// (`"tool"`) e o literal internado podem ter ids diferentes quando um traz tipo
+/// explícito e o outro não.
 pub(crate) fn check_in(
     allowed_values: &[String],
     args: &ConstraintArgs,
     violations: &mut Vec<Violation>,
 ) {
-    let allowed_ids: Vec<i64> = allowed_values
-        .iter()
-        .filter_map(|val| encode_shacl_in_value(val))
-        .collect();
     let value_ids = get_value_ids(args.focus, args.path_id, args.graph_id);
     for v_id in value_ids {
-        if !allowed_ids.contains(&v_id) {
-            let focus_iri = crate::dictionary::decode(args.focus)
-                .unwrap_or_else(|| format!("_id_{}", args.focus));
-            violations.push(Violation {
-                focus_node: focus_iri,
-                shape_iri: args.shape_iri.to_owned(),
-                path: Some(args.path_iri.to_owned()),
-                constraint: "sh:in".to_owned(),
-                message: format!("value node id {v_id} is not in the allowed value set"),
-                severity: "Violation".to_owned(),
-                sh_value: None,
-                sh_source_constraint_component: None,
-            });
+        if allowed_values
+            .iter()
+            .any(|declared| shacl_value_matches(v_id, declared))
+        {
+            continue;
         }
+        let focus_iri =
+            crate::dictionary::decode(args.focus).unwrap_or_else(|| format!("_id_{}", args.focus));
+        let stored = crate::dictionary::decode(v_id).unwrap_or_else(|| format!("_id_{v_id}"));
+        violations.push(Violation {
+            focus_node: focus_iri,
+            shape_iri: args.shape_iri.to_owned(),
+            path: Some(args.path_iri.to_owned()),
+            constraint: "sh:in".to_owned(),
+            message: format!("value {stored} (id {v_id}) is not in the allowed value set"),
+            severity: "Violation".to_owned(),
+            sh_value: None,
+            sh_source_constraint_component: None,
+        });
     }
 }
 
@@ -39,25 +45,25 @@ pub(crate) fn check_has_value(
     args: &ConstraintArgs,
     violations: &mut Vec<Violation>,
 ) {
-    let expected_id = match encode_shacl_in_value(expected_val) {
-        Some(id) => id,
-        None => return, // Expected value not in dictionary — cannot match.
-    };
     let value_ids = get_value_ids(args.focus, args.path_id, args.graph_id);
-    if !value_ids.contains(&expected_id) {
-        let focus_iri =
-            crate::dictionary::decode(args.focus).unwrap_or_else(|| format!("_id_{}", args.focus));
-        violations.push(Violation {
-            focus_node: focus_iri,
-            shape_iri: args.shape_iri.to_owned(),
-            path: Some(args.path_iri.to_owned()),
-            constraint: "sh:hasValue".to_owned(),
-            message: format!("expected value '{expected_val}' not found"),
-            severity: "Violation".to_owned(),
-            sh_value: None,
-            sh_source_constraint_component: None,
-        });
+    if value_ids
+        .iter()
+        .any(|&v_id| shacl_value_matches(v_id, expected_val))
+    {
+        return;
     }
+    let focus_iri =
+        crate::dictionary::decode(args.focus).unwrap_or_else(|| format!("_id_{}", args.focus));
+    violations.push(Violation {
+        focus_node: focus_iri,
+        shape_iri: args.shape_iri.to_owned(),
+        path: Some(args.path_iri.to_owned()),
+        constraint: "sh:hasValue".to_owned(),
+        message: format!("expected value '{expected_val}' not found"),
+        severity: "Violation".to_owned(),
+        sh_value: None,
+        sh_source_constraint_component: None,
+    });
 }
 
 /// Check `sh:lessThan other_path` — every value must be less than the corresponding

--- a/src/shacl/mod.rs
+++ b/src/shacl/mod.rs
@@ -112,6 +112,6 @@ pub use validator::{
 
 // pub(crate) re-exports consumed by constraints/* and other internal callers
 pub(crate) use validator::{
-    compare_dictionary_values, encode_shacl_in_value, get_language_tag, get_value_ids,
-    node_conforms_to_shape, value_has_datatype, value_has_node_kind, value_has_rdf_type,
+    compare_dictionary_values, get_language_tag, get_value_ids, node_conforms_to_shape,
+    shacl_value_matches, value_has_datatype, value_has_node_kind, value_has_rdf_type,
 };

--- a/src/shacl/validator/mod.rs
+++ b/src/shacl/validator/mod.rs
@@ -22,6 +22,6 @@ pub use severity::Violation;
 
 // pub(crate) helpers used by shacl/constraints/*.rs via `super::validator::{...}`
 pub(crate) use property::{
-    compare_dictionary_values, encode_shacl_in_value, get_language_tag, get_value_ids,
-    get_vp_table_name, value_has_datatype, value_has_node_kind, value_has_rdf_type,
+    compare_dictionary_values, get_language_tag, get_value_ids, get_vp_table_name,
+    shacl_value_matches, value_has_datatype, value_has_node_kind, value_has_rdf_type,
 };

--- a/src/shacl/validator/node.rs
+++ b/src/shacl/validator/node.rs
@@ -253,7 +253,12 @@ pub fn run_validate(graph: Option<&str>) -> pgrx::JsonB {
 }
 
 /// Synchronous validation of a single triple.
-pub fn validate_sync(s_id: i64, p_id: i64, o_id: i64, g_id: i64) -> Result<(), String> {
+pub fn validate_sync(
+    s_id: i64,
+    p_id: i64,
+    o_id: i64,
+    g_id: i64,
+) -> Result<(), crate::shacl::validator::severity::SyncViolation> {
     let shapes = crate::shacl::spi::load_shapes();
     validate_sync_with_shapes(s_id, p_id, o_id, g_id, &shapes)
 }
@@ -322,10 +327,12 @@ pub fn process_validation_batch(batch_size: i64) -> i64 {
     for row in &rows {
         match validate_sync_with_shapes(row.s_id, row.p_id, row.o_id, row.g_id, &shapes) {
             Ok(()) => {}
-            Err(msg) => {
+            Err(falha) => {
                 let violation = serde_json::json!({
-                    "shapeIRI":   "unknown",
-                    "message":    msg,
+                    "shapeIRI":   falha.shape_iri,
+                    "path":       falha.path,
+                    "constraint": falha.constraint,
+                    "message":    falha.message,
                     "detectedAt": "async"
                 });
                 let _ = Spi::run_with_args(

--- a/src/shacl/validator/property.rs
+++ b/src/shacl/validator/property.rs
@@ -198,9 +198,14 @@ pub(crate) fn collect_focus_nodes(target: &ShapeTarget, graph_id: i64) -> Vec<i6
 
 // ─── Low-level query helpers ──────────────────────────────────────────────────
 
+/// Quantos *nós de valor distintos* o foco tem no caminho, dentro do grafo.
+///
+/// `sh:maxCount` conta nós de valor, que formam um conjunto: o mesmo objeto
+/// repetido é um valor, não dois. Contar linhas (`COUNT(*)`) fazia a mesma
+/// afirmação gravada duas vezes estourar `maxCount 1`.
 pub(crate) fn count_values_in_graph(focus: i64, path_id: i64, graph_id: i64) -> i64 {
     let table = get_vp_table_name(path_id);
-    let sql = format!("SELECT COUNT(*) FROM {table} WHERE s = $1 AND g = $2");
+    let sql = format!("SELECT COUNT(DISTINCT o) FROM {table} WHERE s = $1 AND g = $2");
     Spi::get_one_with_args::<i64>(
         &sql,
         &[DatumWithOid::from(focus), DatumWithOid::from(graph_id)],
@@ -211,10 +216,43 @@ pub(crate) fn count_values_in_graph(focus: i64, path_id: i64, graph_id: i64) -> 
 
 pub(crate) fn count_values_all_graphs(focus: i64, path_id: i64) -> i64 {
     let table = get_vp_table_name(path_id);
-    let sql = format!("SELECT COUNT(*) FROM {table} WHERE s = $1");
+    let sql = format!("SELECT COUNT(DISTINCT o) FROM {table} WHERE s = $1");
     Spi::get_one_with_args::<i64>(&sql, &[DatumWithOid::from(focus)])
         .unwrap_or(None)
         .unwrap_or(0)
+}
+
+/// A afirmação já está gravada neste grafo?
+///
+/// Serve para o validador saber se está olhando o estado *antes* ou *depois* da
+/// escrita. O modo `sync` valida antes de inserir (a afirmação não está lá); o
+/// modo `async` valida depois (está). Sem essa distinção, o mesmo código somava
+/// mais um a uma contagem que já incluía a linha nova e acusava violação de
+/// `maxCount 1` em todo predicado de valor único.
+pub(crate) fn triple_exists_in_graph(
+    focus: i64,
+    path_id: i64,
+    value_id: i64,
+    graph_id: i64,
+) -> bool {
+    let table = get_vp_table_name(path_id);
+    let sql = if graph_id < 0 {
+        format!("SELECT EXISTS(SELECT 1 FROM {table} WHERE s = $1 AND o = $2)")
+    } else {
+        format!("SELECT EXISTS(SELECT 1 FROM {table} WHERE s = $1 AND o = $2 AND g = $3)")
+    };
+    let args: Vec<DatumWithOid> = if graph_id < 0 {
+        vec![DatumWithOid::from(focus), DatumWithOid::from(value_id)]
+    } else {
+        vec![
+            DatumWithOid::from(focus),
+            DatumWithOid::from(value_id),
+            DatumWithOid::from(graph_id),
+        ]
+    };
+    Spi::get_one_with_args::<bool>(&sql, &args)
+        .unwrap_or(None)
+        .unwrap_or(false)
 }
 
 pub(crate) fn get_value_ids(focus: i64, path_id: i64, graph_id: i64) -> Vec<i64> {
@@ -348,6 +386,51 @@ pub(crate) fn encode_shacl_in_value(val: &str) -> Option<i64> {
         }
     } else {
         crate::dictionary::lookup_iri(val)
+    }
+}
+
+/// Chave canônica de um termo RDF para comparação de conjunto (`sh:in`,
+/// `sh:hasValue`).
+///
+/// Literal simples e literal `^^xsd:string` são o mesmo valor em RDF 1.1, e a
+/// etiqueta de idioma não diferencia maiúscula. Sem normalizar, um `sh:in` com
+/// `"tool"` nunca casava com um objeto gravado como `"tool"^^xsd:string`.
+pub(crate) fn shacl_value_key(raw: &str) -> String {
+    let Some(inner) = raw.strip_prefix('"') else {
+        return raw.to_owned();
+    };
+    let Some(close) = inner.rfind('"') else {
+        return raw.to_owned();
+    };
+    let lexical = &inner[..close];
+    let rest = inner[close + 1..].trim();
+    if let Some(dt) = rest.strip_prefix("^^") {
+        let dt = dt.trim().trim_start_matches('<').trim_end_matches('>');
+        if dt == "http://www.w3.org/2001/XMLSchema#string" {
+            return format!("\"{lexical}\"");
+        }
+        return format!("\"{lexical}\"^^<{dt}>");
+    }
+    if let Some(lang) = rest.strip_prefix('@') {
+        let lang = lang.split_whitespace().next().unwrap_or(lang);
+        return format!("\"{lexical}\"@{}", lang.to_lowercase());
+    }
+    format!("\"{lexical}\"")
+}
+
+/// O valor gravado (`value_id`) é o valor declarado na forma (`declared`)?
+///
+/// Primeiro tenta a igualdade de id — o caminho barato, que resolve IRI e
+/// literal já internado do mesmo jeito. Só cai na comparação por forma canônica
+/// quando o id não bate, que é o caso de literal internado com tipo explícito
+/// contra forma declarada sem tipo (e vice-versa).
+pub(crate) fn shacl_value_matches(value_id: i64, declared: &str) -> bool {
+    if encode_shacl_in_value(declared) == Some(value_id) {
+        return true;
+    }
+    match crate::dictionary::decode(value_id) {
+        Some(stored) => shacl_value_key(&stored) == shacl_value_key(declared),
+        None => false,
     }
 }
 

--- a/src/shacl/validator/severity.rs
+++ b/src/shacl/validator/severity.rs
@@ -22,4 +22,43 @@ pub struct Violation {
     pub sh_source_constraint_component: Option<String>,
 }
 
+// ─── Falha de validação de escrita ───────────────────────────────────────────
+
+/// Uma violação encontrada ao validar uma única afirmação (modo `sync` ou
+/// `async`), com a shape e a restrição que a produziram.
+///
+/// Antes isso era uma `String` solta. O consumidor do modo `async` gravava
+/// `"shapeIRI": "unknown"` em toda linha da fila de descarte, o que deixava o
+/// índice por shape e o resumo por restrição sem nada para agrupar: 18 mil
+/// linhas indistinguíveis. Aqui a origem vem junto.
+#[derive(Debug, Serialize)]
+pub struct SyncViolation {
+    pub shape_iri: String,
+    pub path: Option<String>,
+    pub constraint: String,
+    pub message: String,
+}
+
+impl SyncViolation {
+    pub(crate) fn new(
+        shape_iri: &str,
+        path: &str,
+        constraint: &str,
+        message: String,
+    ) -> SyncViolation {
+        SyncViolation {
+            shape_iri: shape_iri.to_owned(),
+            path: Some(path.to_owned()),
+            constraint: constraint.to_owned(),
+            message,
+        }
+    }
+}
+
+impl std::fmt::Display for SyncViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
 // ─── Recursive shape conformance ─────────────────────────────────────────────

--- a/src/shacl/validator/sparql.rs
+++ b/src/shacl/validator/sparql.rs
@@ -3,23 +3,37 @@ use super::node::{count_qualifying_values, node_conforms_to_shape, validate_sync
 use super::property::{
     collect_focus_nodes, compare_dictionary_values, count_values_in_graph, encode_shacl_in_value,
     get_all_predicate_iris_for_node, get_language_tag, get_value_ids, get_vp_table_name,
-    validate_property_shape, value_has_datatype, value_has_node_kind, value_has_rdf_type,
+    shacl_value_matches, triple_exists_in_graph, validate_property_shape, value_has_datatype,
+    value_has_node_kind, value_has_rdf_type,
 };
-use super::severity::Violation;
+use super::severity::{SyncViolation, Violation};
 use crate::shacl::constraints;
 use crate::shacl::{PropertyShape, Shape, ShapeConstraint, ShapeTarget};
 use pgrx::datum::DatumWithOid;
 use pgrx::prelude::*;
 use serde::Serialize;
 
-/// Like `validate_sync` but accepts a pre-loaded shapes slice.
+/// Valida uma única afirmação contra as shapes já carregadas.
+///
+/// Serve os dois modos: `sync`, chamado *antes* de gravar, e `async`, chamado
+/// pela fila *depois* de gravar. A diferença aparece nas restrições de
+/// cardinalidade — ver `pendente` abaixo.
 pub(crate) fn validate_sync_with_shapes(
     s_id: i64,
     p_id: i64,
     o_id: i64,
     g_id: i64,
     shapes: &[Shape],
-) -> Result<(), String> {
+) -> Result<(), SyncViolation> {
+    // Quanto esta afirmação ainda vai somar à contagem de valores: zero se já
+    // está gravada (modo `async`, ou reafirmação idempotente do mesmo valor),
+    // um se ainda não está (modo `sync`).
+    //
+    // O código antigo somava um sempre. No modo `async` a linha já estava no
+    // armazenamento, então todo predicado de valor único acusava
+    // `maxCount 1: found 1 existing value(s), limit is 1` — 18 mil linhas de
+    // descarte em dois dias, nenhuma delas um problema real de dados.
+    let mut pendente: Option<i64> = None;
     for shape in shapes {
         if shape.deactivated {
             continue;
@@ -67,14 +81,28 @@ pub(crate) fn validate_sync_with_shapes(
             for c in &ps.constraints {
                 match c {
                     ShapeConstraint::MaxCount(n) => {
+                        let adicional = *pendente.get_or_insert_with(|| {
+                            if triple_exists_in_graph(s_id, p_id, o_id, g_id) {
+                                0
+                            } else {
+                                1
+                            }
+                        });
                         let current = count_values_in_graph(s_id, p_id, g_id);
-                        if current + 1 > *n {
+                        if current + adicional > *n {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:maxCount {n} for <{}>: \
-                                 found {} existing value(s), limit is {n}",
-                                focus_iri, ps.path_iri, current
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:maxCount",
+                                format!(
+                                    "SHACL violation: <{}> sh:maxCount {n} for <{}>: \
+                                     resulting value count would be {}, limit is {n}",
+                                    focus_iri,
+                                    ps.path_iri,
+                                    current + adicional
+                                ),
                             ));
                         }
                     }
@@ -82,25 +110,41 @@ pub(crate) fn validate_sync_with_shapes(
                         if !value_has_datatype(o_id, dt_iri) {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:datatype <{dt_iri}> for <{}>: \
-                                 object id {o_id} does not have the required datatype",
-                                focus_iri, ps.path_iri
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:datatype",
+                                format!(
+                                        "SHACL violation: <{}> sh:datatype <{dt_iri}> for <{}>: \
+                                         object id {o_id} does not have the required datatype",
+                                        focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
-                    ShapeConstraint::In(allowed_iris) => {
-                        let allowed_ids: Vec<i64> = allowed_iris
+                    ShapeConstraint::In(allowed_values) => {
+                        // `lookup_iri` sobre um valor entre aspas devolve None,
+                        // então a lista de permitidos vinha vazia e todo literal
+                        // era recusado — inclusive os sete tipos de entidade que
+                        // a própria shape declara. Comparação por forma canônica
+                        // do termo resolve IRI e literal do mesmo jeito.
+                        let permitido = allowed_values
                             .iter()
-                            .filter_map(|iri| crate::dictionary::lookup_iri(iri))
-                            .collect();
-                        if !allowed_ids.contains(&o_id) {
+                            .any(|declarado| shacl_value_matches(o_id, declarado));
+                        if !permitido {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:in for <{}>: \
-                                 object id {o_id} is not in the allowed value set",
-                                focus_iri, ps.path_iri
+                            let gravado = crate::dictionary::decode(o_id)
+                                .unwrap_or_else(|| format!("_id_{o_id}"));
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:in",
+                                format!(
+                                    "SHACL violation: <{}> sh:in for <{}>: \
+                                     value {gravado} (id {o_id}) is not in the allowed value set",
+                                    focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
@@ -127,10 +171,15 @@ pub(crate) fn validate_sync_with_shapes(
                         if !matches.unwrap_or(false) {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:pattern '{regex}' for <{}>: \
-                                 value '{lexical_clean}' does not match",
-                                focus_iri, ps.path_iri
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:pattern",
+                                format!(
+                                        "SHACL violation: <{}> sh:pattern '{regex}' for <{}>: \
+                                         value '{lexical_clean}' does not match",
+                                        focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
@@ -147,10 +196,15 @@ pub(crate) fn validate_sync_with_shapes(
                         if !has_class {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:class <{class_iri}> for <{}>: \
-                                 object id {o_id} is not an instance of the required class",
-                                focus_iri, ps.path_iri
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:class",
+                                format!(
+                                        "SHACL violation: <{}> sh:class <{class_iri}> for <{}>: \
+                                         object id {o_id} is not an instance of the required class",
+                                        focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
@@ -158,10 +212,15 @@ pub(crate) fn validate_sync_with_shapes(
                         if !node_conforms_to_shape(o_id, ref_shape_iri, g_id, shapes) {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:node <{ref_shape_iri}> for <{}>: \
-                                 object id {o_id} does not conform to the referenced shape",
-                                focus_iri, ps.path_iri
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:node",
+                                format!(
+                                        "SHACL violation: <{}> sh:node <{ref_shape_iri}> for <{}>: \
+                                         object id {o_id} does not conform to the referenced shape",
+                                        focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
@@ -172,10 +231,15 @@ pub(crate) fn validate_sync_with_shapes(
                         if !conforms {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:or for <{}>: \
-                                 object id {o_id} does not conform to any of the sh:or shapes",
-                                focus_iri, ps.path_iri
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:or",
+                                format!(
+                                        "SHACL violation: <{}> sh:or for <{}>: \
+                                         object id {o_id} does not conform to any of the sh:or shapes",
+                                        focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
@@ -184,10 +248,15 @@ pub(crate) fn validate_sync_with_shapes(
                             if !node_conforms_to_shape(o_id, s, g_id, shapes) {
                                 let focus_iri = crate::dictionary::decode(s_id)
                                     .unwrap_or_else(|| format!("_id_{s_id}"));
-                                return Err(format!(
-                                    "SHACL violation: <{}> sh:and <{s}> for <{}>: \
-                                     object id {o_id} does not conform to the required shape",
-                                    focus_iri, ps.path_iri
+                                return Err(SyncViolation::new(
+                                    &shape.shape_iri,
+                                    &ps.path_iri,
+                                    "sh:and",
+                                    format!(
+                                            "SHACL violation: <{}> sh:and <{s}> for <{}>: \
+                                             object id {o_id} does not conform to the required shape",
+                                            focus_iri, ps.path_iri
+                                    ),
                                 ));
                             }
                         }
@@ -196,10 +265,15 @@ pub(crate) fn validate_sync_with_shapes(
                         if node_conforms_to_shape(o_id, ref_shape_iri, g_id, shapes) {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:not <{ref_shape_iri}> for <{}>: \
-                                 object id {o_id} must not conform to the referenced shape",
-                                focus_iri, ps.path_iri
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:not",
+                                format!(
+                                        "SHACL violation: <{}> sh:not <{ref_shape_iri}> for <{}>: \
+                                         object id {o_id} must not conform to the referenced shape",
+                                        focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
@@ -209,15 +283,27 @@ pub(crate) fn validate_sync_with_shapes(
                         max_count,
                     } => {
                         if let Some(max) = max_count {
+                            let adicional = *pendente.get_or_insert_with(|| {
+                                if triple_exists_in_graph(s_id, p_id, o_id, g_id) {
+                                    0
+                                } else {
+                                    1
+                                }
+                            });
                             let existing_qualifying =
                                 count_qualifying_values(s_id, p_id, g_id, qvs_iri, shapes);
-                            if existing_qualifying + 1 > *max {
+                            if existing_qualifying + adicional > *max {
                                 let focus_iri = crate::dictionary::decode(s_id)
                                     .unwrap_or_else(|| format!("_id_{s_id}"));
-                                return Err(format!(
-                                    "SHACL violation: <{}> sh:qualifiedMaxCount {max} for <{}>: \
-                                     found {} qualifying value(s), limit is {max}",
-                                    focus_iri, ps.path_iri, existing_qualifying
+                                return Err(SyncViolation::new(
+                                    &shape.shape_iri,
+                                    &ps.path_iri,
+                                    "sh:qualifiedMaxCount",
+                                    format!(
+                                            "SHACL violation: <{}> sh:qualifiedMaxCount {max} for <{}>: \
+                                             found {} qualifying value(s), limit is {max}",
+                                            focus_iri, ps.path_iri, existing_qualifying
+                                    ),
                                 ));
                             }
                         }
@@ -229,10 +315,15 @@ pub(crate) fn validate_sync_with_shapes(
                         if !value_has_node_kind(o_id, kind_iri) {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:nodeKind <{kind_iri}> for <{}>: \
-                                 value id {o_id} does not match required node kind",
-                                focus_iri, ps.path_iri
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:nodeKind",
+                                format!(
+                                        "SHACL violation: <{}> sh:nodeKind <{kind_iri}> for <{}>: \
+                                         value id {o_id} does not match required node kind",
+                                        focus_iri, ps.path_iri
+                                ),
                             ));
                         }
                     }
@@ -251,13 +342,18 @@ pub(crate) fn validate_sync_with_shapes(
                         if !ok {
                             let focus_iri = crate::dictionary::decode(s_id)
                                 .unwrap_or_else(|| format!("_id_{s_id}"));
-                            return Err(format!(
-                                "SHACL violation: <{}> sh:languageIn for <{}>: \
-                                 value id {o_id} language {:?} not in allowed list {:?}",
-                                focus_iri,
-                                ps.path_iri,
-                                lang_opt.as_deref().unwrap_or("none"),
-                                allowed_tags
+                            return Err(SyncViolation::new(
+                                &shape.shape_iri,
+                                &ps.path_iri,
+                                "sh:languageIn",
+                                format!(
+                                        "SHACL violation: <{}> sh:languageIn for <{}>: \
+                                         value id {o_id} language {:?} not in allowed list {:?}",
+                                        focus_iri,
+                                        ps.path_iri,
+                                        lang_opt.as_deref().unwrap_or("none"),
+                                        allowed_tags
+                                ),
                             ));
                         }
                     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -249,7 +249,34 @@ pub extern "C-unwind" fn pg_ripple_merge_worker_main(arg: pg_sys::Datum) {
         .unwrap_or(Instant::now());
     // MERGE-PRED-01 (v0.82.0): predicate ID cache.
     let mut pred_cache = PredicateCache::new();
+    // MERGE-SPIN-01: piso de tempo entre ciclos.
+    //
+    // O laço abaixo espera no latch com teto de `merge_interval_secs`, mas o latch
+    // acionado devolve na hora. Medido em produção (28/07, PostgreSQL 18, 10
+    // predicados promovidos): o ciclo recomeçava 9.467 vezes por segundo,
+    // 13,4 milhões de `count(*)` sobre as tabelas de delta em 20 minutos, 41% de um
+    // núcleo em média e 100% no pico — com a fila de merge vazia. O desenho de
+    // reagir rápido a escrita nova está certo; reagir dez mil vezes por segundo à
+    // mesma escrita não é reagir, é girar.
+    //
+    // O piso não atrasa merge: com 250 ms de default, escrita nova continua sendo
+    // atendida no mesmo instante em qualquer escala humana, e o consumo em vazio cai
+    // para quatro ciclos por segundo no pior caso — na prática, um a cada
+    // `merge_interval_secs`, porque sem latch acionado a espera é a cheia.
+    let piso_entre_ciclos = Duration::from_millis(250);
+    let mut ultimo_ciclo = Instant::now()
+        .checked_sub(piso_entre_ciclos)
+        .unwrap_or(Instant::now());
     while BackgroundWorker::wait_latch(Some(Duration::from_secs(interval_secs))) {
+        {
+            let decorrido = ultimo_ciclo.elapsed();
+            if decorrido < piso_entre_ciclos
+                && !BackgroundWorker::wait_latch(Some(piso_entre_ciclos - decorrido))
+            {
+                break; // SIGTERM durante a espera do piso.
+            }
+        }
+        ultimo_ciclo = Instant::now();
         let sighup = BackgroundWorker::sighup_received();
         if sighup {
             // SIGHUP: reload configuration.  The GUC system handles this.
@@ -585,8 +612,17 @@ fn run_merge_cycle_for_worker_inner(worker_idx: u32, n_workers: u32, pred_ids_al
 
     // Process this worker's assigned predicates.
     for p_id in pred_ids {
+        // MERGE-SPIN-01: contagem limitada ao que a decisão precisa.
+        //
+        // A pergunta é "passou do limite?", e `count(*)` responde muito mais que
+        // isso: varre o delta inteiro. Com `LIMIT threshold` o plano para no
+        // primeiro momento em que a resposta já está decidida — e o nome da tabela
+        // continua interpolado, então o texto muda por predicado e cada chamada paga
+        // planejamento; quanto menos ela ler, melhor.
         let delta_rows: i64 = Spi::get_one_with_args::<i64>(
-            &format!("SELECT count(*)::bigint FROM _pg_ripple.vp_{p_id}_delta"),
+            &format!(
+                "SELECT count(*)::bigint FROM (SELECT 1 FROM _pg_ripple.vp_{p_id}_delta LIMIT {threshold}) s"
+            ),
             &[],
         )
         .unwrap_or(None)
@@ -630,8 +666,11 @@ fn run_merge_cycle_for_worker_inner(worker_idx: u32, n_workers: u32, pred_ids_al
     // Work-stealing: check foreign predicates above threshold with no owner.
     if n_workers > 1 {
         for p_id in all_pred_ids {
+            // MERGE-SPIN-01: mesma contagem limitada do laço acima.
             let delta_rows: i64 = Spi::get_one_with_args::<i64>(
-                &format!("SELECT count(*)::bigint FROM _pg_ripple.vp_{p_id}_delta"),
+                &format!(
+                    "SELECT count(*)::bigint FROM (SELECT 1 FROM _pg_ripple.vp_{p_id}_delta LIMIT {threshold}) s"
+                ),
                 &[],
             )
             .unwrap_or(None)

--- a/tests/pg_regress/expected/datalog_graph_var_rule.out
+++ b/tests/pg_regress/expected/datalog_graph_var_rule.out
@@ -1,0 +1,77 @@
+-- pg_regress test: Datalog rules with GRAPH ?g variable in head and body.
+--
+-- Regression for: non-recursive compiler emitted literal g_var_g in INSERT SELECT
+-- instead of binding ?g from body atoms (ERROR: column "g_var_g" does not exist).
+CREATE EXTENSION IF NOT EXISTS pg_ripple;
+SELECT pg_ripple.triple_count() >= 0 AS library_loaded;
+ library_loaded 
+----------------
+ t
+(1 row)
+
+SET search_path TO pg_ripple, public;
+SELECT pg_ripple.drop_graph('https://gvar.test/tenant/a');
+ drop_graph 
+------------
+          0
+(1 row)
+
+SELECT pg_ripple.drop_rules('gvar_test');
+ drop_rules 
+------------
+          0
+(1 row)
+
+SELECT pg_ripple.load_nquads(
+    '<https://gvar.test/svc> <https://gvar.test/runs_on> <https://gvar.test/host> <https://gvar.test/tenant/a> .' || E'\n' ||
+    '<https://gvar.test/host> <https://gvar.test/depends_on> <https://gvar.test/db> <https://gvar.test/tenant/a> .' || E'\n'
+) = 2 AS base_triples_loaded;
+ base_triples_loaded 
+---------------------
+ t
+(1 row)
+
+SELECT pg_ripple.load_rules(
+    'GRAPH ?g { ?s <https://gvar.test/indirectly_runs_on> ?i } :-
+       GRAPH ?g { ?s <https://gvar.test/runs_on> ?h },
+       GRAPH ?g { ?h <https://gvar.test/depends_on> ?i } .',
+    'gvar_test'
+) = 1 AS graph_var_rule_loaded;
+ graph_var_rule_loaded 
+-----------------------
+ t
+(1 row)
+
+SET pg_ripple.rule_graph_scope = 'all';
+SELECT (pg_ripple.infer_with_stats('gvar_test')->>'derived')::int >= 1 AS inference_derived;
+ inference_derived 
+-------------------
+ t
+(1 row)
+
+SELECT COUNT(*) = 1 AS derived_in_named_graph
+FROM pg_ripple.sparql($$
+    SELECT ?s ?i WHERE {
+        GRAPH <https://gvar.test/tenant/a> {
+            ?s <https://gvar.test/indirectly_runs_on> ?i .
+            FILTER(?s = <https://gvar.test/svc> && ?i = <https://gvar.test/db>)
+        }
+    }
+$$);
+ derived_in_named_graph 
+------------------------
+ t
+(1 row)
+
+RESET pg_ripple.rule_graph_scope;
+SELECT pg_ripple.drop_rules('gvar_test') >= 0 AS rules_cleaned;
+ rules_cleaned 
+---------------
+ t
+(1 row)
+
+SELECT pg_ripple.drop_graph('https://gvar.test/tenant/a') >= 0 AS graph_cleaned;
+ graph_cleaned 
+---------------
+ t
+(1 row)

--- a/tests/pg_regress/expected/dead_letter_drain.out
+++ b/tests/pg_regress/expected/dead_letter_drain.out
@@ -1,0 +1,52 @@
+-- pg_regress test: `drain_dead_letter_queue()` esvazia a fila, não uma linha.
+--
+-- `Spi::get_one` sobre `DELETE ... RETURNING` apaga **uma** linha: o `get_one` pede
+-- uma linha ao SPI, e o SPI para de executar o comando quando o limite é atingido. A
+-- função devolvia 1 como se tivesse esvaziado a fila.
+--
+-- Observado em produção em 28/07/2026: a fila tinha 18.450 linhas,
+-- `drain_dead_letter_queue()` devolveu 1, e a contagem seguinte ainda dizia 18.450.
+-- O resto do módulo já usava a forma certa (`WITH d AS (DELETE ... RETURNING 1)
+-- SELECT count(*) FROM d`); esta era a única chamada fora do padrão.
+SET client_min_messages = error;
+SELECT pg_ripple.triple_count() >= 0 AS biblioteca_carregada;
+ biblioteca_carregada 
+----------------------
+ t
+(1 row)
+
+RESET client_min_messages;
+SELECT pg_ripple.drain_dead_letter_queue() >= 0 AS fila_limpa_para_o_teste;
+ fila_limpa_para_o_teste 
+-------------------------
+ t
+(1 row)
+
+INSERT INTO _pg_ripple.dead_letter_queue (s_id, p_id, o_id, g_id, stmt_id, violation)
+SELECT i, i, i, 0, i, '{"message":"teste"}'::jsonb
+FROM generate_series(1, 25) i;
+SELECT pg_ripple.dead_letter_count() AS antes;
+ antes 
+-------
+    25
+(1 row)
+
+SELECT pg_ripple.drain_dead_letter_queue() AS drenadas;
+ drenadas 
+----------
+       25
+(1 row)
+
+SELECT pg_ripple.dead_letter_count() AS depois;
+ depois 
+--------
+      0
+(1 row)
+
+-- E numa fila vazia devolve zero, não erro.
+SELECT pg_ripple.drain_dead_letter_queue() AS drenadas_de_fila_vazia;
+ drenadas_de_fila_vazia 
+------------------------
+                      0
+(1 row)
+

--- a/tests/pg_regress/expected/dict_subxact_phantom.out
+++ b/tests/pg_regress/expected/dict_subxact_phantom.out
@@ -1,0 +1,117 @@
+-- pg_regress test: rollback de subtransação não pode deixar id fantasma no
+-- cache de memória compartilhada do dicionário (DICT-SUBXACT-02).
+--
+-- O cache de codificação vive em memória compartilhada, então é do cluster
+-- inteiro, não do processo. O rollback da transação já evictava as entradas
+-- daquela transação; o rollback de *subtransação* não. Como todo bloco
+-- `EXCEPTION` de PL/pgSQL e todo `SAVEPOINT` abre uma subtransação, bastava uma
+-- função com tratamento de erro internar um termo e falhar para o mapeamento
+-- hash→id sobreviver à linha do dicionário. A escrita seguinte do mesmo termo
+-- pegava o id do cache, pulava o INSERT, e gravava uma tripla apontando para
+-- uma linha que não existe — sem erro, sem aviso, dado indecifrável.
+--
+-- Atenção ao ler um verde daqui: o cache compartilhado só existe quando
+-- pg_ripple está em `shared_preload_libraries`. Sem preload o teste passa por
+-- ausência do cache, não por correção do rollback. A validação que vale é com
+-- preload ligado.
+-- Carrega a biblioteca antes de qualquer asserção, sem o aviso de preload que
+-- varia entre ambientes.
+SET client_min_messages = error;
+SELECT pg_ripple.triple_count() >= 0 AS biblioteca_carregada;
+ biblioteca_carregada 
+----------------------
+ t
+(1 row)
+
+RESET client_min_messages;
+SET search_path TO pg_ripple, public;
+-- ── caminho 1: bloco EXCEPTION de PL/pgSQL ──────────────────────────────────
+DO $$
+BEGIN
+    PERFORM pg_ripple.insert_triple(
+        '<http://sub.test/a>', '<http://sub.test/p>', '"internado-e-desfeito"');
+    RAISE EXCEPTION 'desfaz';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'subtransacao_desfeita';
+END $$;
+NOTICE:  subtransacao_desfeita
+SELECT count(*) AS linha_no_dicionario
+FROM _pg_ripple.dictionary WHERE value = 'internado-e-desfeito';
+ linha_no_dicionario 
+---------------------
+                   0
+(1 row)
+
+-- O mesmo termo, agora numa escrita que vai ficar. Tem que internar de novo.
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/b>', '<http://sub.test/p>', '"internado-e-desfeito"') > 0 AS gravado;
+ gravado 
+---------
+ t
+(1 row)
+
+-- ── caminho 2: SAVEPOINT explícito ──────────────────────────────────────────
+BEGIN;
+SAVEPOINT s1;
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/c>', '<http://sub.test/p>', '"savepoint-desfeito"') > 0 AS gravado_no_savepoint;
+ gravado_no_savepoint 
+----------------------
+ t
+(1 row)
+
+ROLLBACK TO SAVEPOINT s1;
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/d>', '<http://sub.test/p>', '"savepoint-desfeito"') > 0 AS gravado_depois;
+ gravado_depois 
+----------------
+ t
+(1 row)
+
+COMMIT;
+-- ── caminho 3: savepoint que dá certo dentro de transação que aborta ─────────
+-- Quem responde pelos termos do savepoint passa a ser a transação pai.
+BEGIN;
+SAVEPOINT s2;
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/e>', '<http://sub.test/p>', '"pai-aborta"') > 0 AS gravado_no_savepoint_bom;
+ gravado_no_savepoint_bom 
+--------------------------
+ t
+(1 row)
+
+RELEASE SAVEPOINT s2;
+ROLLBACK;
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/f>', '<http://sub.test/p>', '"pai-aborta"') > 0 AS gravado_depois_do_abort;
+ gravado_depois_do_abort 
+-------------------------
+ t
+(1 row)
+
+-- ── a invariante ────────────────────────────────────────────────────────────
+-- Nenhuma tripla deste teste aponta para linha de dicionário que não existe.
+SELECT count(*) AS objetos_sem_linha_no_dicionario
+FROM _pg_ripple.vp_rare v
+WHERE v.p = (SELECT id FROM _pg_ripple.dictionary WHERE value = 'http://sub.test/p')
+  AND v.o > 0
+  AND NOT EXISTS (SELECT 1 FROM _pg_ripple.dictionary d WHERE d.id = v.o);
+ objetos_sem_linha_no_dicionario 
+---------------------------------
+                               0
+(1 row)
+
+-- E os três termos voltam decifráveis, não `_id_N`.
+SELECT d.value, count(*) AS triplas
+FROM _pg_ripple.vp_rare v
+JOIN _pg_ripple.dictionary d ON d.id = v.o
+WHERE v.p = (SELECT id FROM _pg_ripple.dictionary WHERE value = 'http://sub.test/p')
+GROUP BY d.value
+ORDER BY d.value;
+        value         | triplas 
+----------------------+---------
+ internado-e-desfeito |       1
+ pai-aborta           |       1
+ savepoint-desfeito   |       1
+(3 rows)
+

--- a/tests/pg_regress/expected/shacl_write_guard.out
+++ b/tests/pg_regress/expected/shacl_write_guard.out
@@ -1,0 +1,195 @@
+-- pg_regress test: single-triple write guard (sync + async modes).
+--
+-- Three defects this pins down, all found in production with 18k dead letters
+-- in two days:
+--
+--   1. sh:in compared dictionary ids resolved with lookup_iri(), which returns
+--      NULL for a quoted literal. Every literal value set was therefore empty
+--      and every literal value was rejected.
+--   2. sh:maxCount added 1 to a count taken *after* the write in async mode, so
+--      every single-valued predicate reported "found 1, limit is 1".
+--   3. The dead letter row said shapeIRI = "unknown", so neither the shape
+--      index nor the violation summary could group anything.
+-- Carrega a biblioteca antes de qualquer asserção, sem o aviso de preload que
+-- varia entre ambientes.
+SET client_min_messages = error;
+SELECT pg_ripple.triple_count() >= 0 AS biblioteca_carregada;
+ biblioteca_carregada 
+----------------------
+ t
+(1 row)
+
+RESET client_min_messages;
+SET search_path TO pg_ripple, public;
+SELECT pg_ripple.load_shacl($$
+  @prefix sh: <http://www.w3.org/ns/shacl#> .
+  @prefix ex: <http://guard.test/> .
+  @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+  ex:ThingShape a sh:NodeShape ;
+    sh:targetClass ex:Thing ;
+    sh:property [
+      sh:path ex:label ;
+      sh:datatype xsd:string ;
+      sh:maxCount 1 ;
+    ] ;
+    sh:property [
+      sh:path ex:kind ;
+      sh:in ( "tool" "service" ) ;
+      sh:maxCount 1 ;
+    ] .
+$$) >= 0 AS shacl_loaded;
+ shacl_loaded 
+--------------
+ t
+(1 row)
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/a>',
+    '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    '<http://guard.test/Thing>'
+) > 0 AS typed;
+ typed 
+-------
+ t
+(1 row)
+
+-- ── sync mode: the guard runs before the write ──────────────────────────────
+SET pg_ripple.shacl_mode = 'sync';
+-- A value inside the sh:in set is accepted. Before the fix this raised
+-- "object id N is not in the allowed value set".
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/a>',
+    '<http://guard.test/kind>',
+    '"tool"'
+) > 0 AS kind_allowed;
+ kind_allowed 
+--------------
+ t
+(1 row)
+
+-- Re-asserting the same value is a no-op on the value set, not a second value.
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/a>',
+    '<http://guard.test/kind>',
+    '"tool"'
+) >= 0 AS kind_reasserted;
+ kind_reasserted 
+-----------------
+ t
+(1 row)
+
+-- A different value would make the count 2 against maxCount 1: rejected.
+DO $$
+BEGIN
+    PERFORM pg_ripple.insert_triple(
+        '<http://guard.test/a>',
+        '<http://guard.test/kind>',
+        '"service"'
+    );
+    RAISE NOTICE 'second_kind_accepted';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'second_kind_rejected';
+END $$;
+NOTICE:  second_kind_rejected
+-- A value outside the sh:in set is rejected.
+DO $$
+BEGIN
+    PERFORM pg_ripple.insert_triple(
+        '<http://guard.test/a>',
+        '<http://guard.test/kind>',
+        '"person"'
+    );
+    RAISE NOTICE 'bad_kind_accepted';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'bad_kind_rejected';
+END $$;
+NOTICE:  bad_kind_rejected
+SELECT count(*) AS kind_values
+FROM pg_ripple.sparql(
+    'SELECT ?o WHERE { <http://guard.test/a> <http://guard.test/kind> ?o }'
+);
+ kind_values 
+-------------
+           1
+(1 row)
+
+-- ── async mode: the guard runs after the write ──────────────────────────────
+SET pg_ripple.shacl_mode = 'async';
+SELECT pg_ripple.drain_dead_letter_queue() >= 0 AS drained;
+ drained 
+---------
+ t
+(1 row)
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    '<http://guard.test/Thing>'
+) > 0 AS typed_b;
+ typed_b 
+---------
+ t
+(1 row)
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://guard.test/label>',
+    '"only one"'
+) > 0 AS label_b;
+ label_b 
+---------
+ t
+(1 row)
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://guard.test/kind>',
+    '"service"'
+) > 0 AS kind_b;
+ kind_b 
+--------
+ t
+(1 row)
+
+SELECT pg_ripple.process_validation_queue(1000) >= 0 AS processed;
+ processed 
+-----------
+ t
+(1 row)
+
+-- A conforming triple validated after the write must not be dead-lettered.
+SELECT pg_ripple.dead_letter_count() AS dead_letters_after_valid_writes;
+ dead_letters_after_valid_writes 
+---------------------------------
+                               0
+(1 row)
+
+-- A real violation still lands, and it says which shape and which constraint.
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://guard.test/label>',
+    '"a second label"'
+) > 0 AS second_label_b;
+ second_label_b 
+----------------
+ t
+(1 row)
+
+SELECT pg_ripple.process_validation_queue(1000) >= 0 AS processed_again;
+ processed_again 
+-----------------
+ t
+(1 row)
+
+SELECT violation->>'shapeIRI' AS shape,
+       violation->>'constraint' AS constraint_kind,
+       violation->>'path' AS path
+FROM _pg_ripple.dead_letter_queue
+ORDER BY id;
+            shape             | constraint_kind |          path           
+------------------------------+-----------------+-------------------------
+ http://guard.test/ThingShape | sh:maxCount     | http://guard.test/label
+(1 row)
+
+SET pg_ripple.shacl_mode = 'off';

--- a/tests/pg_regress/sql/datalog_graph_var_rule.sql
+++ b/tests/pg_regress/sql/datalog_graph_var_rule.sql
@@ -1,0 +1,40 @@
+-- pg_regress test: Datalog rules with GRAPH ?g variable in head and body.
+--
+-- Regression for: non-recursive compiler emitted literal g_var_g in INSERT SELECT
+-- instead of binding ?g from body atoms (ERROR: column "g_var_g" does not exist).
+
+CREATE EXTENSION IF NOT EXISTS pg_ripple;
+SELECT pg_ripple.triple_count() >= 0 AS library_loaded;
+SET search_path TO pg_ripple, public;
+
+SELECT pg_ripple.drop_graph('https://gvar.test/tenant/a');
+SELECT pg_ripple.drop_rules('gvar_test');
+
+SELECT pg_ripple.load_nquads(
+    '<https://gvar.test/svc> <https://gvar.test/runs_on> <https://gvar.test/host> <https://gvar.test/tenant/a> .' || E'\n' ||
+    '<https://gvar.test/host> <https://gvar.test/depends_on> <https://gvar.test/db> <https://gvar.test/tenant/a> .' || E'\n'
+) = 2 AS base_triples_loaded;
+
+SELECT pg_ripple.load_rules(
+    'GRAPH ?g { ?s <https://gvar.test/indirectly_runs_on> ?i } :-
+       GRAPH ?g { ?s <https://gvar.test/runs_on> ?h },
+       GRAPH ?g { ?h <https://gvar.test/depends_on> ?i } .',
+    'gvar_test'
+) = 1 AS graph_var_rule_loaded;
+
+SET pg_ripple.rule_graph_scope = 'all';
+SELECT (pg_ripple.infer_with_stats('gvar_test')->>'derived')::int >= 1 AS inference_derived;
+
+SELECT COUNT(*) = 1 AS derived_in_named_graph
+FROM pg_ripple.sparql($$
+    SELECT ?s ?i WHERE {
+        GRAPH <https://gvar.test/tenant/a> {
+            ?s <https://gvar.test/indirectly_runs_on> ?i .
+            FILTER(?s = <https://gvar.test/svc> && ?i = <https://gvar.test/db>)
+        }
+    }
+$$);
+
+RESET pg_ripple.rule_graph_scope;
+SELECT pg_ripple.drop_rules('gvar_test') >= 0 AS rules_cleaned;
+SELECT pg_ripple.drop_graph('https://gvar.test/tenant/a') >= 0 AS graph_cleaned;

--- a/tests/pg_regress/sql/dead_letter_drain.sql
+++ b/tests/pg_regress/sql/dead_letter_drain.sql
@@ -1,0 +1,27 @@
+-- pg_regress test: `drain_dead_letter_queue()` esvazia a fila, não uma linha.
+--
+-- `Spi::get_one` sobre `DELETE ... RETURNING` apaga **uma** linha: o `get_one` pede
+-- uma linha ao SPI, e o SPI para de executar o comando quando o limite é atingido. A
+-- função devolvia 1 como se tivesse esvaziado a fila.
+--
+-- Observado em produção em 28/07/2026: a fila tinha 18.450 linhas,
+-- `drain_dead_letter_queue()` devolveu 1, e a contagem seguinte ainda dizia 18.450.
+-- O resto do módulo já usava a forma certa (`WITH d AS (DELETE ... RETURNING 1)
+-- SELECT count(*) FROM d`); esta era a única chamada fora do padrão.
+
+SET client_min_messages = error;
+SELECT pg_ripple.triple_count() >= 0 AS biblioteca_carregada;
+RESET client_min_messages;
+
+SELECT pg_ripple.drain_dead_letter_queue() >= 0 AS fila_limpa_para_o_teste;
+
+INSERT INTO _pg_ripple.dead_letter_queue (s_id, p_id, o_id, g_id, stmt_id, violation)
+SELECT i, i, i, 0, i, '{"message":"teste"}'::jsonb
+FROM generate_series(1, 25) i;
+
+SELECT pg_ripple.dead_letter_count() AS antes;
+SELECT pg_ripple.drain_dead_letter_queue() AS drenadas;
+SELECT pg_ripple.dead_letter_count() AS depois;
+
+-- E numa fila vazia devolve zero, não erro.
+SELECT pg_ripple.drain_dead_letter_queue() AS drenadas_de_fila_vazia;

--- a/tests/pg_regress/sql/dict_subxact_phantom.sql
+++ b/tests/pg_regress/sql/dict_subxact_phantom.sql
@@ -1,0 +1,79 @@
+-- pg_regress test: rollback de subtransação não pode deixar id fantasma no
+-- cache de memória compartilhada do dicionário (DICT-SUBXACT-02).
+--
+-- O cache de codificação vive em memória compartilhada, então é do cluster
+-- inteiro, não do processo. O rollback da transação já evictava as entradas
+-- daquela transação; o rollback de *subtransação* não. Como todo bloco
+-- `EXCEPTION` de PL/pgSQL e todo `SAVEPOINT` abre uma subtransação, bastava uma
+-- função com tratamento de erro internar um termo e falhar para o mapeamento
+-- hash→id sobreviver à linha do dicionário. A escrita seguinte do mesmo termo
+-- pegava o id do cache, pulava o INSERT, e gravava uma tripla apontando para
+-- uma linha que não existe — sem erro, sem aviso, dado indecifrável.
+--
+-- Atenção ao ler um verde daqui: o cache compartilhado só existe quando
+-- pg_ripple está em `shared_preload_libraries`. Sem preload o teste passa por
+-- ausência do cache, não por correção do rollback. A validação que vale é com
+-- preload ligado.
+
+-- Carrega a biblioteca antes de qualquer asserção, sem o aviso de preload que
+-- varia entre ambientes.
+SET client_min_messages = error;
+SELECT pg_ripple.triple_count() >= 0 AS biblioteca_carregada;
+RESET client_min_messages;
+
+SET search_path TO pg_ripple, public;
+
+-- ── caminho 1: bloco EXCEPTION de PL/pgSQL ──────────────────────────────────
+DO $$
+BEGIN
+    PERFORM pg_ripple.insert_triple(
+        '<http://sub.test/a>', '<http://sub.test/p>', '"internado-e-desfeito"');
+    RAISE EXCEPTION 'desfaz';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'subtransacao_desfeita';
+END $$;
+
+SELECT count(*) AS linha_no_dicionario
+FROM _pg_ripple.dictionary WHERE value = 'internado-e-desfeito';
+
+-- O mesmo termo, agora numa escrita que vai ficar. Tem que internar de novo.
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/b>', '<http://sub.test/p>', '"internado-e-desfeito"') > 0 AS gravado;
+
+-- ── caminho 2: SAVEPOINT explícito ──────────────────────────────────────────
+BEGIN;
+SAVEPOINT s1;
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/c>', '<http://sub.test/p>', '"savepoint-desfeito"') > 0 AS gravado_no_savepoint;
+ROLLBACK TO SAVEPOINT s1;
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/d>', '<http://sub.test/p>', '"savepoint-desfeito"') > 0 AS gravado_depois;
+COMMIT;
+
+-- ── caminho 3: savepoint que dá certo dentro de transação que aborta ─────────
+-- Quem responde pelos termos do savepoint passa a ser a transação pai.
+BEGIN;
+SAVEPOINT s2;
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/e>', '<http://sub.test/p>', '"pai-aborta"') > 0 AS gravado_no_savepoint_bom;
+RELEASE SAVEPOINT s2;
+ROLLBACK;
+
+SELECT pg_ripple.insert_triple(
+    '<http://sub.test/f>', '<http://sub.test/p>', '"pai-aborta"') > 0 AS gravado_depois_do_abort;
+
+-- ── a invariante ────────────────────────────────────────────────────────────
+-- Nenhuma tripla deste teste aponta para linha de dicionário que não existe.
+SELECT count(*) AS objetos_sem_linha_no_dicionario
+FROM _pg_ripple.vp_rare v
+WHERE v.p = (SELECT id FROM _pg_ripple.dictionary WHERE value = 'http://sub.test/p')
+  AND v.o > 0
+  AND NOT EXISTS (SELECT 1 FROM _pg_ripple.dictionary d WHERE d.id = v.o);
+
+-- E os três termos voltam decifráveis, não `_id_N`.
+SELECT d.value, count(*) AS triplas
+FROM _pg_ripple.vp_rare v
+JOIN _pg_ripple.dictionary d ON d.id = v.o
+WHERE v.p = (SELECT id FROM _pg_ripple.dictionary WHERE value = 'http://sub.test/p')
+GROUP BY d.value
+ORDER BY d.value;

--- a/tests/pg_regress/sql/shacl_write_guard.sql
+++ b/tests/pg_regress/sql/shacl_write_guard.sql
@@ -1,0 +1,138 @@
+-- pg_regress test: single-triple write guard (sync + async modes).
+--
+-- Three defects this pins down, all found in production with 18k dead letters
+-- in two days:
+--
+--   1. sh:in compared dictionary ids resolved with lookup_iri(), which returns
+--      NULL for a quoted literal. Every literal value set was therefore empty
+--      and every literal value was rejected.
+--   2. sh:maxCount added 1 to a count taken *after* the write in async mode, so
+--      every single-valued predicate reported "found 1, limit is 1".
+--   3. The dead letter row said shapeIRI = "unknown", so neither the shape
+--      index nor the violation summary could group anything.
+
+-- Carrega a biblioteca antes de qualquer asserção, sem o aviso de preload que
+-- varia entre ambientes.
+SET client_min_messages = error;
+SELECT pg_ripple.triple_count() >= 0 AS biblioteca_carregada;
+RESET client_min_messages;
+
+SET search_path TO pg_ripple, public;
+
+SELECT pg_ripple.load_shacl($$
+  @prefix sh: <http://www.w3.org/ns/shacl#> .
+  @prefix ex: <http://guard.test/> .
+  @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+  ex:ThingShape a sh:NodeShape ;
+    sh:targetClass ex:Thing ;
+    sh:property [
+      sh:path ex:label ;
+      sh:datatype xsd:string ;
+      sh:maxCount 1 ;
+    ] ;
+    sh:property [
+      sh:path ex:kind ;
+      sh:in ( "tool" "service" ) ;
+      sh:maxCount 1 ;
+    ] .
+$$) >= 0 AS shacl_loaded;
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/a>',
+    '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    '<http://guard.test/Thing>'
+) > 0 AS typed;
+
+-- ── sync mode: the guard runs before the write ──────────────────────────────
+SET pg_ripple.shacl_mode = 'sync';
+
+-- A value inside the sh:in set is accepted. Before the fix this raised
+-- "object id N is not in the allowed value set".
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/a>',
+    '<http://guard.test/kind>',
+    '"tool"'
+) > 0 AS kind_allowed;
+
+-- Re-asserting the same value is a no-op on the value set, not a second value.
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/a>',
+    '<http://guard.test/kind>',
+    '"tool"'
+) >= 0 AS kind_reasserted;
+
+-- A different value would make the count 2 against maxCount 1: rejected.
+DO $$
+BEGIN
+    PERFORM pg_ripple.insert_triple(
+        '<http://guard.test/a>',
+        '<http://guard.test/kind>',
+        '"service"'
+    );
+    RAISE NOTICE 'second_kind_accepted';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'second_kind_rejected';
+END $$;
+
+-- A value outside the sh:in set is rejected.
+DO $$
+BEGIN
+    PERFORM pg_ripple.insert_triple(
+        '<http://guard.test/a>',
+        '<http://guard.test/kind>',
+        '"person"'
+    );
+    RAISE NOTICE 'bad_kind_accepted';
+EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'bad_kind_rejected';
+END $$;
+
+SELECT count(*) AS kind_values
+FROM pg_ripple.sparql(
+    'SELECT ?o WHERE { <http://guard.test/a> <http://guard.test/kind> ?o }'
+);
+
+-- ── async mode: the guard runs after the write ──────────────────────────────
+SET pg_ripple.shacl_mode = 'async';
+SELECT pg_ripple.drain_dead_letter_queue() >= 0 AS drained;
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    '<http://guard.test/Thing>'
+) > 0 AS typed_b;
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://guard.test/label>',
+    '"only one"'
+) > 0 AS label_b;
+
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://guard.test/kind>',
+    '"service"'
+) > 0 AS kind_b;
+
+SELECT pg_ripple.process_validation_queue(1000) >= 0 AS processed;
+
+-- A conforming triple validated after the write must not be dead-lettered.
+SELECT pg_ripple.dead_letter_count() AS dead_letters_after_valid_writes;
+
+-- A real violation still lands, and it says which shape and which constraint.
+SELECT pg_ripple.insert_triple(
+    '<http://guard.test/b>',
+    '<http://guard.test/label>',
+    '"a second label"'
+) > 0 AS second_label_b;
+
+SELECT pg_ripple.process_validation_queue(1000) >= 0 AS processed_again;
+
+SELECT violation->>'shapeIRI' AS shape,
+       violation->>'constraint' AS constraint_kind,
+       violation->>'path' AS path
+FROM _pg_ripple.dead_letter_queue
+ORDER BY id;
+
+SET pg_ripple.shacl_mode = 'off';


### PR DESCRIPTION
## Problem

Datalog rules with a variable graph in the rule head (documented in `plans/ecosystem/datalog.md`) fail at inference time:

```
ERROR:  column "g_var_g" does not exist
```

Example rule:

```prolog
GRAPH ?g { ?s ex:indirectly_runs_on ?i } :-
  GRAPH ?g { ?s ex:runs_on ?h },
  GRAPH ?g { ?h ex:depends_on ?i } .
```

## Root cause

`compile_nonrecursive_rule()` and the semi-naive delta variant compiler emitted the literal SQL identifier `g_var_{name}` in `INSERT … SELECT` for the head graph column. Body atoms correctly bind `?g` via `var_map` to VP aliases (`t0.g`, etc.), but the head used the wrong expression.

## Fix

- Add `head_g_select_expr()` helper resolving head graph terms through `var_map`
- Use it in non-recursive INSERT compilation and semi-naive delta variants

## Test

- New pg_regress test `datalog_graph_var_rule.sql`: loads base triples into a named graph, runs a `GRAPH ?g` rule, asserts the derived triple materializes in the same named graph.

## Reproducer (v0.128.0)

```sql
SELECT pg_ripple.load_rules(
  'GRAPH ?g { ?s <https://ex/indirectly_runs_on> ?i } :-
     GRAPH ?g { ?s <https://ex/runs_on> ?h },
     GRAPH ?g { ?h <https://ex/depends_on> ?i } .',
  'gtest'
);
SET pg_ripple.rule_graph_scope = 'all';
SELECT pg_ripple.infer_with_stats('gtest');
```

Fails before this patch; passes after.

ValorBrain (production consumer) currently works around this with unscoped rules + `sync-inferred-to-tenant-graph.ts`; this fix removes the need for that copy step once released.