### PR TITLE
fix: modify the :path to {path} for `pg_ripple_http/src/routing/mod.rs`

### DIFF
--- a/pg_ripple_http/src/routing/mod.rs
+++ b/pg_ripple_http/src/routing/mod.rs
@@ -363,11 +363,11 @@ pub(crate) fn build_router(state: Arc<AppState>, max_body_bytes: usize, cors: Co
         .route("/temporal/facts", get(temporal_handlers::temporal_facts))
         // v0.125.0 FEAT-02: Temporal graph snapshot and diff endpoints.
         .route(
-            "/temporal/graphs/:iri/snapshot",
+            "/temporal/graphs/{iri}/snapshot",
             get(temporal_handlers::graph_snapshot),
         )
         .route(
-            "/temporal/graphs/:iri/diff",
+            "/temporal/graphs/{iri}/diff",
             get(temporal_handlers::graph_diff),
         )
         // v0.115.0 M16-02: PPRL REST API.
@@ -381,7 +381,7 @@ pub(crate) fn build_router(state: Arc<AppState>, max_body_bytes: usize, cors: Co
         .route("/dp/noisy_histogram", post(dp_handlers::dp_noisy_histogram))
         // v0.118.0 Feature 2: Privacy budget status endpoint.
         .route(
-            "/dp/budget/:dataset/:principal",
+            "/dp/budget/{dataset}/{principal}",
             get(dp_handlers::dp_budget_get),
         )
         // v0.115.0 M16-02: Entity-resolution REST API.


### PR DESCRIPTION
## Summary

fix: #132 

## Checklist

- [ ] Tests pass (`cargo pgrx test pg18`, `cargo pgrx regress pg18`)
- [ ] Formatting and lint clean (`cargo fmt`, `cargo clippy --features pg18 -- -D warnings`)
- [ ] **Documentation**: if this PR changes a user-visible API (function signature, GUC parameter, behavior change), either a `docs/` update is included or a `docs-gap` issue has been filed

## Test

```log
/home/etl/.cargo/bin/cargo run --color=always --bin pg_ripple_http --profile dev --manifest-path /data/lyndon/iProject/rustpath/pg-ripple/pg_ripple_http/Cargo.toml
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
     Running `/data/cargo-target/.target/debug/pg_ripple_http`
2026-07-29T09:02:27.337873Z  INFO pg_ripple_http: connected to postgresql://ontology:xxxx@xxx.xxx.xxx.xxx:5432/ontology_v1 (port 7878), triple store contains 0 triples
2026-07-29T09:02:27.365376Z  INFO pg_ripple_http: pg_ripple extension compatibility check ext_version=0.128.0 min_supported=0.127.0
2026-07-29T09:02:27.393755Z  INFO pg_ripple_http: PG_RIPPLE_HTTP_METRICS_TOKEN set: GET /metrics requires Authorization: Bearer <token>
2026-07-29T09:02:27.393944Z  WARN pg_ripple_http: CORS is permissive (*). Set PG_RIPPLE_HTTP_CORS_ORIGINS to a comma-separated list of allowed origins for production use. Monitor pg_ripple_http_cors_permissive_requests_total for cross-origin traffic.
2026-07-29T09:02:27.397189Z  INFO pg_ripple_http: pg_ripple_http listening on http://0.0.0.0:7878
^C2026-07-29T09:02:29.457114Z  INFO pg_ripple_http: received Ctrl+C, initiating graceful shutdown (30s drain)

```