### PR TITLE
release: v0.128.1 — emergency containment and safe patch

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -13,4 +13,10 @@ ignore = [
     "RUSTSEC-2024-0436",
     # paste: proc-macro crate unsoundness.  Only used at compile time.
     "RUSTSEC-2026-0104",
+    # quick-xml: DoS-only advisories (quadratic attribute scan; unbounded namespace
+    # allocation). Pinned by unmaintained rio_xml (direct dep) and by oxrdfxml/
+    # sparesults via oxigraph (dev-dependency only); no fixed release available yet.
+    # See audit.toml at the repo root for the full triage note.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
       - name: Check pg_ripple_http compiles
         run: cargo check -p pg_ripple_http
 
+      # v0.128.1 (http-router-construction): compiling is not enough — Axum 0.8
+      # panics at router-construction time on obsolete `:capture` routes, which
+      # only surfaces once the binary actually runs. This builds the full
+      # router and dispatches a request to every registered route, with no
+      # live PostgreSQL connection required.
+      - name: pg_ripple_http router construction & startup gate
+        run: cargo test -p pg_ripple_http --test router_construction
+
       # v0.62.0 N7-5: cargo deny — licence, duplicate and advisory checks.
       - name: Install cargo-deny
         run: |
@@ -227,6 +235,19 @@ jobs:
 
       - name: Install extension into live instance
         run: cargo pgrx install --pg-config ~/.pgrx/18.*/pgrx-install/bin/pg_config --release 2>/dev/null || cargo pgrx install --pg-config $(find ~/.pgrx -name pg_config | head -1) 2>/dev/null || echo "Install skipped — pg_config path not found"
+
+      # v0.128.1 (http-process-smoke): start the real pg_ripple_http binary
+      # against the live pgrx instance, poll /health and /ready, and verify a
+      # clean exit on SIGTERM. Catches startup crashes that a compile-only or
+      # in-process router check cannot (e.g. failing to bind, or an unclean
+      # shutdown path).
+      - name: pg_ripple_http process smoke test
+        run: |
+          psql "host=localhost port=28818 dbname=postgres user=${USER}" \
+            -c "CREATE EXTENSION IF NOT EXISTS pg_ripple;"
+          cargo build -p pg_ripple_http
+          PG_RIPPLE_HTTP_PG_URL="postgresql://${USER}@localhost:28818/postgres" \
+            bash pg_ripple_http/tests/process_smoke.sh
 
       - name: Validate examples (live, L15-03)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,6 +539,16 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "Image digest: $DIGEST"
 
+      # v0.128.1 (container-auth-negative-test): the production image must
+      # never accept passwordless remote PostgreSQL connections by default —
+      # docker/00-pg_hba.sh used to add unconditional trust rules to every
+      # built image. Verify against the digest just pushed, not a local
+      # rebuild.
+      - name: Verify production image rejects passwordless auth by default
+        run: |
+          IMAGE_REF="ghcr.io/trickle-labs/pg-ripple@${{ steps.digest.outputs.digest }}" \
+            bash tests/container/test_pg_hba.sh
+
       # v0.60.0 N7-4 / v0.64.0 TRUTH-04: Docker CVE scan — fail release if
       # HIGH/CRITICAL CVEs found. Scan the immutable digest, not the mutable tag.
       - name: Run Trivy vulnerability scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,74 @@ Versions correspond to the milestones in [ROADMAP.md](ROADMAP.md).
 
 ## [Unreleased]
 
+---
+
+## [0.128.1] — 2026-08-26 — Emergency Containment and Safe Patch
+
+**Out-of-band safety patch for v0.128.0. Fixes three critical issues found
+after that release: the HTTP companion could crash on startup instead of serving traffic, the
+production Docker image accepted passwordless remote database connections,
+and async JSON writeback could report itself as enabled without a working
+event path. Nothing new is added — this release only removes unsafe
+behavior; see
+[plans/pg-ripple-production-readiness-plan.md](plans/pg-ripple-production-readiness-plan.md#v01281--emergency-containment-and-safe-patch)
+for the full remediation plan.**
+
+### Security
+
+- **Production Docker image accepted passwordless remote PostgreSQL
+  connections** — `docker/00-pg_hba.sh` unconditionally added `trust` rules
+  for all external TCP connections to every built image, including
+  production pulls; any client that could reach the port got an
+  unauthenticated superuser connection. The script is now inert unless the
+  operator explicitly sets `PG_RIPPLE_DEV_TRUST_AUTH=1` (development only —
+  never set this on a reachable deployment). `docker-compose.yml` now binds
+  PostgreSQL to `127.0.0.1` by default. Added
+  `tests/container/test_pg_hba.sh`, which confirms passwordless TCP auth
+  fails, SCRAM auth with the configured password succeeds, and local
+  Unix-socket access is unaffected.
+
 ### Fixed
 
-- **CI: CloudNativePG extension image publishing** — Added `docker-cnpg` job to
-  release workflow to build and publish the extension volume image with the
+- **HTTP companion could panic during startup instead of serving traffic** —
+  three routes (`/temporal/graphs/:iri/snapshot`, `/temporal/graphs/:iri/diff`,
+  `/dp/budget/:dataset/:principal`) still used the Axum 0.7 `:capture` path
+  syntax, which Axum 0.8 rejects with a panic at router-construction time —
+  the process would exit before ever binding a port or answering `/health`.
+  All routes now use the `{capture}` syntax Axum 0.8 requires. Added
+  `pg_ripple_http/tests/router_construction.rs`, which builds the full
+  router and dispatches a request to every registered route without a live
+  PostgreSQL connection, and `pg_ripple_http/tests/process_smoke.sh`, which
+  starts the real binary against a real database, polls `/health` and
+  `/ready`, and verifies a clean exit on `SIGTERM`.
+- **`enable_json_writeback()` could report success while leaving predicates
+  uncovered** — it always set `writeback_enabled = true` even when a
+  predicate's dictionary entry or VP delta table did not exist yet, or a
+  trigger failed to install, silently under-covering the async writeback
+  event path (RDF changes for uncovered predicates were never enqueued for
+  relational writeback). It now fails with a descriptive error and leaves
+  `writeback_enabled = false` unless every mapped predicate got a working
+  enqueue trigger. Direct writeback via `writeback_json_row()` and
+  `writeback_json_row_delete()` is unaffected. `pg_ripple.feature_status()`
+  now reports `json_mapping_writeback` as `broken` pending the full
+  trigger-architecture repair in v0.129.0. Added regression coverage in
+  `tests/pg_regress/sql/v0128_json_writeback.sql` (JWB-22).
+- **CI (`release.yml`): CloudNativePG extension image publishing** — Added a
+  `docker-cnpg` job to build and publish the extension volume image with the
   `-cnpg` suffix on each tagged release. The `docker/Dockerfile.cnpg` existed
   but was never built by CI, causing `docker pull
   ghcr.io/trickle-labs/pg-ripple:<version>-cnpg` to fail with "not found". Now
   the extension image is published automatically alongside the main extension
   and HTTP companion images.
+
+### Technical Details
+
+- `pg_ripple_http` gained a library target (`src/lib.rs`) re-exporting
+  `routing`, `common`, and `metrics` so integration tests can build the
+  router in-process; `main.rs` is now a thin binary over that library.
+  `routing::build_router()` is `pub` instead of `pub(crate)`.
+- `src/feature_status.rs` documents a new `broken` status value in its
+  taxonomy: "known correctness defect; do not rely on this in production."
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "pg_ripple"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "pg_ripple_http"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "arrow",
  "axum",
@@ -2141,6 +2141,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-stream",
+ "tower",
  "tower-http",
  "tower_governor",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrow"
@@ -863,7 +863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1054,11 +1054,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1092,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1649,9 +1651,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]
@@ -1891,7 +1893,7 @@ dependencies = [
  "sparesults",
  "spareval",
  "spargebra",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1919,7 +1921,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "ryu-js",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1934,7 +1936,7 @@ dependencies = [
  "oxsdatatypes",
  "rand 0.9.3",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1947,7 +1949,7 @@ dependencies = [
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1960,7 +1962,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1969,7 +1971,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1982,7 +1984,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2343,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64",
  "byteorder",
@@ -2361,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2489,14 +2491,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2594,6 +2597,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -2757,7 +2769,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3113,7 +3125,7 @@ dependencies = [
  "memchr",
  "oxrdf",
  "quick-xml 0.37.5",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3136,7 +3148,7 @@ dependencies = [
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3150,7 +3162,7 @@ dependencies = [
  "oxrdf",
  "peg",
  "rand 0.9.3",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3265,7 +3277,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3392,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4073,7 +4085,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [".", "pg_ripple_http"]
 
 [package]
 name = "pg_ripple"
-version = "0.128.0"
+version = "0.128.1"
 edition = "2024"
 description = "High-performance RDF triple store with native SPARQL query execution for PostgreSQL 18"
 license = "Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@
 #     ghcr.io/trickle-labs/pg-ripple:latest
 #
 # Authentication:
-#   The container is configured for development/testing with trust authentication
-#   enabled for external TCP connections. See docker/00-pg_hba.sh for details.
-#   For production deployments, use password-based authentication instead.
+#   v0.128.1: SCRAM authentication (the postgres:18 base image default) applies
+#   to all TCP connections out of the box — the image no longer weakens this.
+#   For local development ONLY, set PG_RIPPLE_DEV_TRUST_AUTH=1 to make
+#   docker/00-pg_hba.sh add passwordless trust rules for external TCP
+#   connections. Never set this in a production or otherwise reachable
+#   deployment. See docker/00-pg_hba.sh for details.
 
 # ── Build stage ───────────────────────────────────────────────────────────────
 # Build a fresh gosu binary from source using Go 1.26 (fixes all gosu stdlib

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ No separate graph database. No data pipelines. No extra infrastructure.
 
 ---
 
-## What works today (v0.126.0)
+## What works today (v0.128.1)
 
-pg_ripple passes **100% of the W3C SPARQL 1.1, SHACL Core, and OWL 2 RL conformance test suites** — the industry benchmarks for correctness in knowledge graph systems. After 126 releases it covers the full feature set described below.
+pg_ripple passes **100% of the W3C SPARQL 1.1, SHACL Core, and OWL 2 RL conformance test suites** — the industry benchmarks for correctness in knowledge graph systems. After 128 releases it covers the full feature set described below.
 
 | What you can do | How it works |
 |---|---|
@@ -179,7 +179,13 @@ Token budgets matter. `sparql_construct_jsonld()` takes a SPARQL CONSTRUCT query
 
 ## Where we're headed
 
-One release remains on the path to v1.0.0.
+v0.128.1 is an out-of-band safety patch — a router-construction crash in the
+`pg_ripple_http` companion, a Docker image default that accepted passwordless
+remote database connections, and an async JSON-writeback path that could
+report itself enabled without full coverage. See
+[ROADMAP.md](ROADMAP.md#production-readiness--ga-qualification-v01281--v01370)
+for the full v0.129.0–v0.137.0 production-readiness sequence still ahead of
+v1.0.0.
 
 The v0.91.0–v0.111.0 development cycle adds deep reasoning capabilities: proof trees and justification infrastructure (v0.100.0), natural-language explanation of derived facts via LLM or deterministic fallback (v0.101.0), what-if hypothetical inference (v0.102.0), Datalog conflict detection (v0.103.0), versioned domain rule libraries (v0.104.0), guided rule authoring with LLM-backed NL-to-Datalog translation (v0.105.0), first-class temporal fact store with AFTER/BEFORE/DURING operators and CDC integration (v0.106.0–v0.107.0), Bayesian confidence updates with evidence log and derivation-DAG propagation (v0.108.0), neuro-symbolic record linkage with six string-similarity built-ins and a five-stage `resolve_entities()` pipeline (v0.109.0), NS-RL evaluation harness with live ER monitoring stream tables and rule explainability (v0.110.0), and Privacy-Preserving Record Linkage via CLK Bloom-filter encoding and differential-privacy aggregates (v0.111.0). Every row in `pg_ripple.feature_status()` shows `implemented`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -303,7 +303,7 @@
 
 | Version | Theme | Status | Release type | Primary gate |
 |---------|-------|--------|--------------|--------------|
-| [v0.128.1](plans/pg-ripple-production-readiness-plan.md#v01281--emergency-containment-and-safe-patch) | Emergency containment and safe patch | Planned | Out-of-band patch | No startup panic, no passwordless production image, no false-enabled async writeback |
+| [v0.128.1](plans/pg-ripple-production-readiness-plan.md#v01281--emergency-containment-and-safe-patch) | Emergency containment and safe patch | ✅ Released | Out-of-band patch | No startup panic, no passwordless production image, no false-enabled async writeback |
 | [v0.129.0](plans/pg-ripple-production-readiness-plan.md#v01290--json-writeback-and-mutation-integrity) | JSON writeback and mutation integrity | Planned | Correctness release | Full insert/update/delete/retry/restart writeback matrix passes |
 | [v0.130.0](plans/pg-ripple-production-readiness-plan.md#v01300--installation-and-migration-integrity) | Installation and migration integrity | Planned | Upgrade release | Fresh install and every supported upgrade path are schema- and behavior-equivalent |
 | [v0.131.0](plans/pg-ripple-production-readiness-plan.md#v01310--secure-by-default-runtime-and-packaging) | Secure-by-default runtime and packaging | Planned | Security release | Production deployments fail closed and least privilege is verified |

--- a/audit.toml
+++ b/audit.toml
@@ -49,6 +49,20 @@ ignore = [
     # No upstream fixed version available as of 2026-05-19 review.
     # Expiry: 2027-01-01 — re-audit when paste releases a fixed version.
     { id = "RUSTSEC-2026-0104", reason = "paste is a compile-time proc-macro only; unsoundness is in macro internals with no runtime impact on generated code — verified 2026-05-19 (SEC-M-02)", expires = "2027-01-01" },
+    # quick-xml: two DoS advisories (quadratic attribute scan; unbounded namespace
+    # allocation), fixed upstream in quick-xml >=0.41.0.
+    # quick-xml 0.36.2 is pinned by rio_xml (direct dependency, used to parse RDF/XML
+    # documents supplied via pg_ripple's bulk-load functions) and 0.37.5 is pinned by
+    # oxrdfxml/sparesults, reached only through oxigraph as a dev-dependency (test-only,
+    # not shipped in the extension binary). rio_xml is unmaintained (upstream points to
+    # oxrdfxml) and has not released a version depending on a fixed quick-xml.
+    # Triage 2026-08-26: both advisories are availability (CPU/memory exhaustion) only,
+    # not memory corruption. RDF/XML loading requires a database role already trusted to
+    # execute SQL against pg_ripple, the same trust boundary as other bulk-load paths.
+    # No upstream fix exists yet; tracked for replacement by migrating off rio_xml to
+    # oxrdfxml/oxttl (the maintained oxigraph parser family).
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml pinned by unmaintained rio_xml (direct dep, RDF/XML bulk load) and oxigraph dev-dep chain; no fixed release available; DoS-only, requires a trusted DB role", expires = "2027-02-26" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml pinned by unmaintained rio_xml (direct dep, RDF/XML bulk load) and oxigraph dev-dep chain; no fixed release available; DoS-only, requires a trusted DB role", expires = "2027-02-26" },
 ]
 
 # pg_trgm: PostgreSQL contrib module used for fuzzy SPARQL (v0.87.0 CONF-SBOM-01)

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,14 @@ ignore = [
     { id = "RUSTSEC-2024-0436", reason = "pre-existing unmaintained transitive dependency; tracked for replacement" },
     # RUSTSEC-2021-0127: pre-existing advisory
     { id = "RUSTSEC-2021-0127", reason = "pre-existing transitive dependency advisory; tracked for upstream fix" },
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195: quick-xml DoS advisories (2026-08-26 audit).
+    # quick-xml 0.36.2 is pinned by rio_xml (direct dep, RDF/XML parsing) and 0.37.5 by
+    # oxrdfxml/sparesults via oxigraph (dev-dependency only). rio_xml is unmaintained
+    # (upstream recommends oxrdfxml) and neither pinning has released a fix. Both
+    # advisories are DoS-only (CPU/memory exhaustion on a crafted document), not memory
+    # corruption. Tracked for replacement via migration to oxrdfxml/oxttl.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml pinned by unmaintained rio_xml (direct dep) and oxigraph dev-dep chain; no fixed release available; DoS-only" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml pinned by unmaintained rio_xml (direct dep) and oxigraph dev-dep chain; no fixed release available; DoS-only" },
 ]
 
 [licenses]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/trickle-labs/pg_ripple:0.128.0
+    image: ghcr.io/trickle-labs/pg_ripple:0.128.1
     environment:
       # S13-07 (v0.86.0): use POSTGRES_PASSWORD_FILE instead of plain-text password.
       # Generate: mkdir -p secrets && openssl rand -base64 32 > secrets/pg_password.txt
       POSTGRES_PASSWORD_FILE: /run/secrets/pg_password
     secrets:
       - pg_password
+    ports:
+      # v0.128.1: bind to loopback only by default — change to "5432:5432" to
+      # expose PostgreSQL beyond this host, e.g. for a real remote deployment.
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -45,7 +49,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/trickle-labs/pg_ripple:0.128.0
+    image: ghcr.io/trickle-labs/pg_ripple:0.128.1
     entrypoint: ["/usr/local/bin/pg_ripple_http"]
     ports:
       - "7878:7878"

--- a/docker/00-pg_hba.sh
+++ b/docker/00-pg_hba.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# 00-pg_hba.sh  
-# Modifies PostgreSQL authentication configuration to allow TCP connections.
+# 00-pg_hba.sh
+# Opt-in: adds passwordless (trust) rules for external TCP connections.
 #
 # Background:
 # The official postgres:18 Docker image generates pg_hba.conf during initdb with
@@ -8,10 +8,19 @@
 # When pg_ripple's Docker image is used with port forwarding, the connection source
 # IP may not match the localhost-only trust rules, causing authentication to fail.
 #
-# This script adds trust rules for external TCP connections so the container is
-# easily accessible from the host during development/testing.
+# v0.128.1 (emergency containment): this script used to apply unconditionally,
+# so every pg_ripple image — including production pulls — accepted passwordless
+# remote PostgreSQL connections. It is now inert unless the operator explicitly
+# opts in with PG_RIPPLE_DEV_TRUST_AUTH=1. NEVER set this in a production or
+# otherwise network-reachable deployment — anyone who can reach the port gets
+# an unauthenticated superuser connection.
 
 set -e
+
+if [ "$PG_RIPPLE_DEV_TRUST_AUTH" != "1" ]; then
+  echo "INFO: PG_RIPPLE_DEV_TRUST_AUTH not set to 1, skipping pg_hba.conf trust rules (SCRAM auth stays in effect)"
+  exit 0
+fi
 
 # PGDATA is set by the official postgres entrypoint
 if [ -z "$PGDATA" ]; then

--- a/justfile
+++ b/justfile
@@ -263,37 +263,37 @@ release VERSION:
 [group: "release"]
 bump-version NEW_VERSION COMPAT_MIN="":
     @OLD_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/'); \
-     echo "Bumping $$OLD_VERSION → {{NEW_VERSION}}"; \
-     sed -i '' "s/^version = \"$$OLD_VERSION\"/version = \"{{NEW_VERSION}}\"/" Cargo.toml; \
-     sed -i '' "s/^version = \"$$OLD_VERSION\"/version = \"{{NEW_VERSION}}\"/" pg_ripple_http/Cargo.toml; \
-     sed -i '' "s/^default_version = '$$OLD_VERSION'/default_version = '{{NEW_VERSION}}'/" pg_ripple.control; \
+     echo "Bumping $OLD_VERSION → {{NEW_VERSION}}"; \
+     sed -i '' "s/^version = \"$OLD_VERSION\"/version = \"{{NEW_VERSION}}\"/" Cargo.toml; \
+     sed -i '' "s/^version = \"$OLD_VERSION\"/version = \"{{NEW_VERSION}}\"/" pg_ripple_http/Cargo.toml; \
+     sed -i '' "s/^default_version = '$OLD_VERSION'/default_version = '{{NEW_VERSION}}'/" pg_ripple.control; \
      sed -i '' "s/^comment = '.*'/comment = 'High-performance RDF triple store with SPARQL 1.1, SHACL, Datalog, HTAP, federation, and Datalog-native PageRank (v{{NEW_VERSION}})'/" pg_ripple.control; \
      if [ -n "{{COMPAT_MIN}}" ]; then \
        OLD_COMPAT=$(grep 'COMPATIBLE_EXTENSION_MIN' pg_ripple_http/src/main.rs | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"' | head -1); \
-       sed -i '' "s/COMPATIBLE_EXTENSION_MIN: \&str = \"$$OLD_COMPAT\"/COMPATIBLE_EXTENSION_MIN: \&str = \"{{COMPAT_MIN}}\"/" pg_ripple_http/src/main.rs; \
-       echo "Updated COMPATIBLE_EXTENSION_MIN: $$OLD_COMPAT → {{COMPAT_MIN}}"; \
+       sed -i '' "s/COMPATIBLE_EXTENSION_MIN: \&str = \"$OLD_COMPAT\"/COMPATIBLE_EXTENSION_MIN: \&str = \"{{COMPAT_MIN}}\"/" pg_ripple_http/src/main.rs; \
+       echo "Updated COMPATIBLE_EXTENSION_MIN: $OLD_COMPAT → {{COMPAT_MIN}}"; \
      fi; \
-     sed -i '' "s|ghcr.io/trickle-labs/pg-ripple:$$OLD_VERSION|ghcr.io/trickle-labs/pg-ripple:{{NEW_VERSION}}|g" docker-compose.yml; \
-     MIGRATION_FILE="sql/pg_ripple--$$OLD_VERSION--{{NEW_VERSION}}.sql"; \
-     if [ ! -f "$$MIGRATION_FILE" ]; then \
-       printf -- "-- Migration $$OLD_VERSION → {{NEW_VERSION}}\n-- Schema changes: TODO\n" > "$$MIGRATION_FILE"; \
-       echo "Created $$MIGRATION_FILE"; \
+     sed -i '' "s|ghcr.io/trickle-labs/pg_ripple:$OLD_VERSION|ghcr.io/trickle-labs/pg_ripple:{{NEW_VERSION}}|g" docker-compose.yml; \
+     MIGRATION_FILE="sql/pg_ripple--$OLD_VERSION--{{NEW_VERSION}}.sql"; \
+     if [ ! -f "$MIGRATION_FILE" ]; then \
+       printf -- "-- Migration $OLD_VERSION → {{NEW_VERSION}}\n-- Schema changes: TODO\n" > "$MIGRATION_FILE"; \
+       echo "Created $MIGRATION_FILE"; \
      else \
-       echo "$$MIGRATION_FILE already exists"; \
+       echo "$MIGRATION_FILE already exists"; \
      fi; \
-     CHANGELOG_SECTION="## v{{NEW_VERSION}} — $(date +%Y-%m-%d)\n\n### Added\n- TODO\n\n### Changed\n- TODO\n\n### Fixed\n- TODO\n\n"; \
-     if grep -q "## v{{NEW_VERSION}}" CHANGELOG.md 2>/dev/null; then \
-       echo "CHANGELOG.md already contains ## v{{NEW_VERSION}} section"; \
+     CHANGELOG_SECTION="## [{{NEW_VERSION}}] — $(date +%Y-%m-%d)\n\n### Added\n- TODO\n\n### Changed\n- TODO\n\n### Fixed\n- TODO\n\n"; \
+     if grep -q "## \[{{NEW_VERSION}}\]" CHANGELOG.md 2>/dev/null; then \
+       echo "CHANGELOG.md already contains ## [{{NEW_VERSION}}] section"; \
      else \
        TMP=$(mktemp); \
-       awk -v section="$$CHANGELOG_SECTION" '/^## v[0-9]/{if(!done){printf section; done=1}} {print}' CHANGELOG.md > "$$TMP" && mv "$$TMP" CHANGELOG.md; \
+       awk -v section="$CHANGELOG_SECTION" '/^## \[[0-9]/{if(!done){printf section; done=1}} {print}' CHANGELOG.md > "$TMP" && mv "$TMP" CHANGELOG.md; \
        echo "Added CHANGELOG.md section for v{{NEW_VERSION}}"; \
      fi; \
      echo ""; \
      echo "=== Version bump complete ==="; \
      echo "Files updated: Cargo.toml, pg_ripple_http/Cargo.toml, pg_ripple.control,"; \
      echo "  docker-compose.yml, CHANGELOG.md"; \
-     echo "Next: fill in CHANGELOG.md and $$MIGRATION_FILE"
+     echo "Next: fill in CHANGELOG.md and $MIGRATION_FILE"
 
 # Dry-run for bump-version: prints proposed changes without writing any files.
 # ROAD-02 (v0.89.0)
@@ -301,23 +301,23 @@ bump-version NEW_VERSION COMPAT_MIN="":
 [group: "release"]
 bump-version-dry NEW_VERSION:
     @OLD_VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/'); \
-     echo "=== bump-version dry-run: $$OLD_VERSION → {{NEW_VERSION}} ==="; \
+     echo "=== bump-version dry-run: $OLD_VERSION → {{NEW_VERSION}} ==="; \
      echo ""; \
      echo "[Cargo.toml]          version = \"{{NEW_VERSION}}\""; \
      echo "[pg_ripple_http/Cargo.toml] version = \"{{NEW_VERSION}}\""; \
      echo "[pg_ripple.control]   default_version = '{{NEW_VERSION}}'"; \
      echo "[pg_ripple_http/src/main.rs] COMPATIBLE_EXTENSION_MIN = \"{{NEW_VERSION}}\""; \
-     echo "[docker-compose.yml]  ghcr.io/trickle-labs/pg-ripple:{{NEW_VERSION}}"; \
-     MIGRATION_FILE="sql/pg_ripple--$$OLD_VERSION--{{NEW_VERSION}}.sql"; \
-     if [ -f "$$MIGRATION_FILE" ]; then \
-       echo "[migration]           $$MIGRATION_FILE (already exists)"; \
+     echo "[docker-compose.yml]  ghcr.io/trickle-labs/pg_ripple:{{NEW_VERSION}}"; \
+     MIGRATION_FILE="sql/pg_ripple--$OLD_VERSION--{{NEW_VERSION}}.sql"; \
+     if [ -f "$MIGRATION_FILE" ]; then \
+       echo "[migration]           $MIGRATION_FILE (already exists)"; \
      else \
-       echo "[migration]           $$MIGRATION_FILE (will be created)"; \
+       echo "[migration]           $MIGRATION_FILE (will be created)"; \
      fi; \
-     if grep -q "## v{{NEW_VERSION}}" CHANGELOG.md 2>/dev/null; then \
-       echo "[CHANGELOG.md]        ## v{{NEW_VERSION}} section already exists"; \
+     if grep -q "## \[{{NEW_VERSION}}\]" CHANGELOG.md 2>/dev/null; then \
+       echo "[CHANGELOG.md]        ## [{{NEW_VERSION}}] section already exists"; \
      else \
-       echo "[CHANGELOG.md]        ## v{{NEW_VERSION}} stub section will be added"; \
+       echo "[CHANGELOG.md]        ## [{{NEW_VERSION}}] stub section will be added"; \
      fi; \
      echo ""; \
      echo "Run 'just bump-version {{NEW_VERSION}}' to apply."
@@ -336,32 +336,32 @@ regen-sbom:
 # COMPATIBLE_EXTENSION_MIN in pg_ripple_http/src/main.rs, docker-compose.yml.
 [group: "release"]
 check-version-sync:
-    @CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | grep -oP '"\K[^"]+'); \
-     HTTP_VER=$(grep '^version = ' pg_ripple_http/Cargo.toml | head -1 | grep -oP '"\K[^"]+'); \
-     CTRL_VER=$(grep '^default_version' pg_ripple.control | grep -oP "'\K[^']+"); \
-     COMPAT_VER=$(grep 'COMPATIBLE_EXTENSION_MIN' pg_ripple_http/src/main.rs | grep -oP '"\K[0-9]+\.[0-9]+\.[0-9]+' | head -1); \
-     DC_VER=$(grep 'ghcr.io/trickle-labs/pg-ripple:' docker-compose.yml | grep -oP ':\K[0-9.]+' | head -1); \
+    @CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/'); \
+     HTTP_VER=$(grep '^version = ' pg_ripple_http/Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/'); \
+     CTRL_VER=$(grep '^default_version' pg_ripple.control | sed "s/.*'\([^']*\)'.*/\1/"); \
+     COMPAT_VER=$(grep 'COMPATIBLE_EXTENSION_MIN' pg_ripple_http/src/main.rs | head -1 | sed 's/.*"\([0-9]*\.[0-9]*\.[0-9]*\)".*/\1/'); \
+     DC_VER=$(grep 'ghcr.io/trickle-labs/pg_ripple:' docker-compose.yml | head -1 | sed 's/.*pg_ripple:\([0-9.]*\).*/\1/'); \
      FAIL=0; \
-     echo "Cargo.toml:              $$CARGO_VER"; \
-     echo "pg_ripple_http:          $$HTTP_VER"; \
-     echo "pg_ripple.control:       $$CTRL_VER"; \
-     echo "COMPATIBLE_EXTENSION_MIN: $$COMPAT_VER"; \
-     echo "docker-compose.yml:      $$DC_VER"; \
-     [ "$$CARGO_VER" = "$$HTTP_VER" ]   || { echo "FAIL: pg_ripple_http version mismatch"; FAIL=1; }; \
-     [ "$$CARGO_VER" = "$$CTRL_VER" ]   || { echo "FAIL: pg_ripple.control version mismatch"; FAIL=1; }; \
-     [ "$$CARGO_VER" = "$$DC_VER" ]     || { echo "FAIL: docker-compose.yml image tag mismatch"; FAIL=1; }; \
-     LOWEST=$(printf '%s\n%s' "$$COMPAT_VER" "$$CARGO_VER" | sort -V | head -1); \
-     [ "$$LOWEST" = "$$COMPAT_VER" ] || { echo "FAIL: COMPATIBLE_EXTENSION_MIN ($$COMPAT_VER) > extension version ($$CARGO_VER)"; FAIL=1; }; \
-     if [ $$FAIL -eq 0 ]; then echo "OK: all versions consistent at $$CARGO_VER (COMPAT_MIN=$$COMPAT_VER)"; fi; \
-     exit $$FAIL
+     echo "Cargo.toml:              $CARGO_VER"; \
+     echo "pg_ripple_http:          $HTTP_VER"; \
+     echo "pg_ripple.control:       $CTRL_VER"; \
+     echo "COMPATIBLE_EXTENSION_MIN: $COMPAT_VER"; \
+     echo "docker-compose.yml:      $DC_VER"; \
+     [ "$CARGO_VER" = "$HTTP_VER" ]   || { echo "FAIL: pg_ripple_http version mismatch"; FAIL=1; }; \
+     [ "$CARGO_VER" = "$CTRL_VER" ]   || { echo "FAIL: pg_ripple.control version mismatch"; FAIL=1; }; \
+     [ "$CARGO_VER" = "$DC_VER" ]     || { echo "FAIL: docker-compose.yml image tag mismatch"; FAIL=1; }; \
+     LOWEST=$(printf '%s\n%s' "$COMPAT_VER" "$CARGO_VER" | sort -V | head -1); \
+     [ "$LOWEST" = "$COMPAT_VER" ] || { echo "FAIL: COMPATIBLE_EXTENSION_MIN ($COMPAT_VER) > extension version ($CARGO_VER)"; FAIL=1; }; \
+     if [ $FAIL -eq 0 ]; then echo "OK: all versions consistent at $CARGO_VER (COMPAT_MIN=$COMPAT_VER)"; fi; \
+     exit $FAIL
 
 # BUILD-02 (v0.84.0): Regenerate the OpenAPI spec from the running HTTP service.
 # Requires pg_ripple_http to be running on $PG_RIPPLE_HTTP_URL (default: http://localhost:3000).
 [group: "release"]
 regen-openapi:
-    @URL=$${PG_RIPPLE_HTTP_URL:-http://localhost:3000}; \
-     echo "Fetching OpenAPI spec from $$URL/openapi.json"; \
-     curl -fsSL "$$URL/openapi.json" -o pg_ripple_http/openapi.json && \
+    @URL=${PG_RIPPLE_HTTP_URL:-http://localhost:3000}; \
+     echo "Fetching OpenAPI spec from $URL/openapi.json"; \
+     curl -fsSL "$URL/openapi.json" -o pg_ripple_http/openapi.json && \
      echo "Saved to pg_ripple_http/openapi.json"; \
      if command -v yq >/dev/null 2>&1; then \
        yq -P pg_ripple_http/openapi.json > pg_ripple_http/openapi.yaml && \
@@ -385,36 +385,36 @@ generate-helm-values TENANT="":
        echo "Usage: just generate-helm-values TENANT=<name>"; \
        exit 1; \
      fi; \
-     URL=$${PG_RIPPLE_HTTP_URL:-http://localhost:7878}; \
+     URL=${PG_RIPPLE_HTTP_URL:-http://localhost:7878}; \
      OUTFILE="values-{{TENANT}}.yaml"; \
-     echo "Fetching tenant '{{TENANT}}' from $$URL/tenants/{{TENANT}} ..."; \
-     RESPONSE=$$(curl -fsSL "$$URL/tenants/{{TENANT}}" 2>&1); \
-     if [ $$? -ne 0 ]; then \
-       echo "ERROR: could not fetch tenant from $$URL/tenants/{{TENANT}}"; \
-       echo "Response: $$RESPONSE"; \
+     echo "Fetching tenant '{{TENANT}}' from $URL/tenants/{{TENANT}} ..."; \
+     RESPONSE=$(curl -fsSL "$URL/tenants/{{TENANT}}" 2>&1); \
+     if [ $? -ne 0 ]; then \
+       echo "ERROR: could not fetch tenant from $URL/tenants/{{TENANT}}"; \
+       echo "Response: $RESPONSE"; \
        exit 1; \
      fi; \
-     GRAPH_IRI=$$(echo "$$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('graph_iri',''))"); \
-     QUOTA=$$(echo "$$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('quota_triples', 0))"); \
-     echo "# pg_ripple per-tenant Helm values for tenant: {{TENANT}}" > $$OUTFILE; \
-     echo "# Generated by: just generate-helm-values TENANT={{TENANT}}" >> $$OUTFILE; \
-     echo "tenant:" >> $$OUTFILE; \
-     echo "  name: \"{{TENANT}}\"" >> $$OUTFILE; \
-     echo "  graphIri: \"$$GRAPH_IRI\"" >> $$OUTFILE; \
-     echo "  quotaTriples: $$QUOTA" >> $$OUTFILE; \
-     echo "Wrote $$OUTFILE"; \
-     cat $$OUTFILE
+     GRAPH_IRI=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('graph_iri',''))"); \
+     QUOTA=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('quota_triples', 0))"); \
+     echo "# pg_ripple per-tenant Helm values for tenant: {{TENANT}}" > $OUTFILE; \
+     echo "# Generated by: just generate-helm-values TENANT={{TENANT}}" >> $OUTFILE; \
+     echo "tenant:" >> $OUTFILE; \
+     echo "  name: \"{{TENANT}}\"" >> $OUTFILE; \
+     echo "  graphIri: \"$GRAPH_IRI\"" >> $OUTFILE; \
+     echo "  quotaTriples: $QUOTA" >> $OUTFILE; \
+     echo "Wrote $OUTFILE"; \
+     cat $OUTFILE
 
 # SBOM-03: Verify that sbom.json version matches Cargo.toml version.
 # Fails with exit 1 if they differ (prevents stale SBOM in releases).
 [group: "release"]
 check-sbom-version:
-    @CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | grep -oP '"\\K[^"]+'); \
-     SBOM_VER=$(python3 -c "import json; print(json.load(open('sbom.json'))['version'])"); \
-     if [ "$$CARGO_VER" = "$$SBOM_VER" ]; then \
-       echo "OK: sbom.json version matches Cargo.toml ($$CARGO_VER)"; \
+    @CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/'); \
+     SBOM_VER=$(python3 -c "import json; print(json.load(open('sbom.json')).get('metadata',{}).get('component',{}).get('version','MISSING'))"); \
+     if [ "$CARGO_VER" = "$SBOM_VER" ]; then \
+       echo "OK: sbom.json version matches Cargo.toml ($CARGO_VER)"; \
      else \
-       echo "FAIL: sbom.json version ($$SBOM_VER) != Cargo.toml version ($$CARGO_VER)"; \
+       echo "FAIL: sbom.json version ($SBOM_VER) != Cargo.toml version ($CARGO_VER)"; \
        echo "Regenerate sbom.json with: cargo cyclonedx --format json"; \
        exit 1; \
      fi
@@ -449,12 +449,12 @@ assess-release VERSION="":
     bash scripts/check_readme_version.sh
     @echo ""
     @echo "--- Version sync check ---"
-    @CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | grep -oP '"\\K[^"]+'); \
-     CTRL_VER=$(grep '^default_version' pg_ripple.control | grep -oP "'\\K[^']+"); \
-     if [ "$$CARGO_VER" = "$$CTRL_VER" ]; then \
-       echo "OK: Cargo.toml and pg_ripple.control both at v$$CARGO_VER"; \
+    @CARGO_VER=$(grep '^version = ' Cargo.toml | head -1 | sed 's/.*"\([^"]*\)".*/\1/'); \
+     CTRL_VER=$(grep '^default_version' pg_ripple.control | sed "s/.*'\([^']*\)'.*/\1/"); \
+     if [ "$CARGO_VER" = "$CTRL_VER" ]; then \
+       echo "OK: Cargo.toml and pg_ripple.control both at v$CARGO_VER"; \
      else \
-       echo "FAIL: version mismatch — Cargo.toml=$$CARGO_VER control=$$CTRL_VER"; exit 1; \
+       echo "FAIL: version mismatch — Cargo.toml=$CARGO_VER control=$CTRL_VER"; exit 1; \
      fi
     @if [ -n "{{VERSION}}" ]; then \
        echo ""; \

--- a/pg_ripple.control
+++ b/pg_ripple.control
@@ -1,8 +1,8 @@
 # Extension control file for pg_ripple.
 # See: https://www.postgresql.org/docs/current/extend-extensions.html
 
-comment = 'High-performance RDF triple store with SPARQL 1.1, SHACL, Datalog, HTAP, federation, and Datalog-native PageRank (v0.128.0)'
-default_version = '0.128.0'
+comment = 'High-performance RDF triple store with SPARQL 1.1, SHACL, Datalog, HTAP, federation, and Datalog-native PageRank (v0.128.1)'
+default_version = '0.128.1'
 # MUST match the current release version (keep in sync with Cargo.toml)
 module_pathname = '$libdir/pg_ripple'
 relocatable = false

--- a/pg_ripple_http/Cargo.toml
+++ b/pg_ripple_http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_ripple_http"
-version = "0.128.0"
+version = "0.128.1"
 edition = "2024"
 description = "SPARQL 1.1 Protocol HTTP endpoint for pg_ripple — connects PostgreSQL 18 RDF triple store to the web"
 license = "Apache-2.0"
@@ -9,6 +9,10 @@ readme = "../README.md"
 keywords = ["sparql", "rdf", "postgresql", "knowledge-graph", "linked-data"]
 categories = ["database", "command-line-utilities", "web-programming::http-server"]
 rust-version = "1.88"
+
+[lib]
+name = "pg_ripple_http"
+path = "src/lib.rs"
 
 [[bin]]
 name = "pg_ripple_http"
@@ -38,3 +42,6 @@ hmac = "0.13"
 sha2 = "0.11"
 hex = "0.4"
 dashmap = "6"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/pg_ripple_http/pg_ripple_http.cdx.json
+++ b/pg_ripple_http/pg_ripple_http.cdx.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
   "version": 1,
-  "serialNumber": "urn:uuid:4c38eac6-2026-4ed1-b902-f0c693431082",
+  "serialNumber": "urn:uuid:6c3befc8-2430-41dc-859d-43be0831c4dc",
   "metadata": {
-    "timestamp": "2026-05-21T20:19:28.970067000Z",
+    "timestamp": "2026-08-26T18:33:13.307977000Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.127.0",
+      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1",
       "name": "pg_ripple_http",
-      "version": "0.127.0",
+      "version": "0.128.1",
       "description": "SPARQL 1.1 Protocol HTTP endpoint for pg_ripple — connects PostgreSQL 18 RDF triple store to the web",
       "scope": "required",
       "licenses": [
@@ -24,7 +24,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/pg_ripple_http@0.127.0?download_url=file://.",
+      "purl": "pkg:cargo/pg_ripple_http@0.128.1?download_url=file://.",
       "externalReferences": [
         {
           "type": "vcs",
@@ -33,11 +33,18 @@
       ],
       "components": [
         {
-          "type": "application",
-          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.127.0 bin-target-0",
+          "type": "library",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1 bin-target-0",
           "name": "pg_ripple_http",
-          "version": "0.127.0",
-          "purl": "pkg:cargo/pg_ripple_http@0.127.0?download_url=file://.#src/main.rs"
+          "version": "0.128.1",
+          "purl": "pkg:cargo/pg_ripple_http@0.128.1?download_url=file://.#src/lib.rs"
+        },
+        {
+          "type": "application",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1 bin-target-1",
+          "name": "pg_ripple_http",
+          "version": "0.128.1",
+          "purl": "pkg:cargo/pg_ripple_http@0.128.1?download_url=file://.#src/main.rs"
         }
       ]
     },
@@ -7570,7 +7577,7 @@
   ],
   "dependencies": [
     {
-      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.127.0",
+      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#axum@0.8.9",

--- a/pg_ripple_http/sbom.json
+++ b/pg_ripple_http/sbom.json
@@ -2,9 +2,9 @@
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
   "version": 1,
-  "serialNumber": "urn:uuid:a80faa94-8686-4aca-b735-e0e8e4231bce",
+  "serialNumber": "urn:uuid:75a8e528-d1a8-4699-87ae-2081c7a8543b",
   "metadata": {
-    "timestamp": "2026-05-09T19:45:13.861708000Z",
+    "timestamp": "2026-08-26T18:33:34.801050000Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "application",
-      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.101.0",
+      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1",
       "name": "pg_ripple_http",
-      "version": "0.101.0",
+      "version": "0.128.1",
       "description": "SPARQL 1.1 Protocol HTTP endpoint for pg_ripple — connects PostgreSQL 18 RDF triple store to the web",
       "scope": "required",
       "licenses": [
@@ -24,7 +24,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/pg_ripple_http@0.101.0?download_url=file://.",
+      "purl": "pkg:cargo/pg_ripple_http@0.128.1?download_url=file://.",
       "externalReferences": [
         {
           "type": "vcs",
@@ -33,11 +33,18 @@
       ],
       "components": [
         {
-          "type": "application",
-          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.101.0 bin-target-0",
+          "type": "library",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1 bin-target-0",
           "name": "pg_ripple_http",
-          "version": "0.101.0",
-          "purl": "pkg:cargo/pg_ripple_http@0.101.0?download_url=file://.#src/main.rs"
+          "version": "0.128.1",
+          "purl": "pkg:cargo/pg_ripple_http@0.128.1?download_url=file://.#src/lib.rs"
+        },
+        {
+          "type": "application",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1 bin-target-1",
+          "name": "pg_ripple_http",
+          "version": "0.128.1",
+          "purl": "pkg:cargo/pg_ripple_http@0.128.1?download_url=file://.#src/main.rs"
         }
       ]
     },
@@ -148,16 +155,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-arith",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Arrow arithmetic kernels",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "e754319ed8a85d817fe7adf183227e0b5308b82790a737b426c1124626b48118"
+          "content": "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
         }
       ],
       "licenses": [
@@ -165,7 +172,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-arith@58.2.0",
+      "purl": "pkg:cargo/arrow-arith@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -179,16 +186,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-array",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Array abstractions for Apache Arrow",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
+          "content": "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
         }
       ],
       "licenses": [
@@ -196,7 +203,7 @@
           "expression": "Apache-2.0 AND MIT"
         }
       ],
-      "purl": "pkg:cargo/arrow-array@58.2.0",
+      "purl": "pkg:cargo/arrow-array@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -210,16 +217,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-buffer",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Buffer abstractions for Apache Arrow",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
+          "content": "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
         }
       ],
       "licenses": [
@@ -227,7 +234,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-buffer@58.2.0",
+      "purl": "pkg:cargo/arrow-buffer@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -241,16 +248,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-cast",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Cast kernel and utilities for Apache Arrow",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
+          "content": "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
         }
       ],
       "licenses": [
@@ -258,7 +265,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-cast@58.2.0",
+      "purl": "pkg:cargo/arrow-cast@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -272,16 +279,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-data",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Array data abstractions for Apache Arrow",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
+          "content": "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
         }
       ],
       "licenses": [
@@ -289,7 +296,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-data@58.2.0",
+      "purl": "pkg:cargo/arrow-data@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -303,16 +310,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-ipc",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Support for the Arrow IPC format",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "fd8907ddd8f9fbabf91ec2c85c1d81fe2874e336d2443eb36373595e28b98dd5"
+          "content": "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
         }
       ],
       "licenses": [
@@ -320,7 +327,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-ipc@58.2.0",
+      "purl": "pkg:cargo/arrow-ipc@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -334,16 +341,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-ord",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Ordering kernels for arrow arrays",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
+          "content": "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
         }
       ],
       "licenses": [
@@ -351,7 +358,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-ord@58.2.0",
+      "purl": "pkg:cargo/arrow-ord@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -365,16 +372,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-row",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Arrow row format",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "faec88a945338192beffbbd4be0def70135422930caa244ac3cec0cd213b26b4"
+          "content": "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
         }
       ],
       "licenses": [
@@ -382,7 +389,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-row@58.2.0",
+      "purl": "pkg:cargo/arrow-row@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -396,16 +403,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-schema",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Defines the logical types for arrow arrays",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
+          "content": "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
         }
       ],
       "licenses": [
@@ -413,7 +420,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-schema@58.2.0",
+      "purl": "pkg:cargo/arrow-schema@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -427,16 +434,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-select",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Selection kernels for arrow arrays",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
+          "content": "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
         }
       ],
       "licenses": [
@@ -444,7 +451,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-select@58.2.0",
+      "purl": "pkg:cargo/arrow-select@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -458,16 +465,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow-string",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "String kernels for arrow arrays",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
+          "content": "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
         }
       ],
       "licenses": [
@@ -475,7 +482,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow-string@58.2.0",
+      "purl": "pkg:cargo/arrow-string@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -489,16 +496,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow@58.2.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0",
       "author": "Apache Arrow <dev@arrow.apache.org>",
       "name": "arrow",
-      "version": "58.2.0",
+      "version": "58.3.0",
       "description": "Rust implementation of Apache Arrow",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "607e64bb911ee4f90483e044fe78f175989148c2892e659a2cd25429e782ec54"
+          "content": "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
         }
       ],
       "licenses": [
@@ -506,7 +513,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/arrow@58.2.0",
+      "purl": "pkg:cargo/arrow@58.3.0",
       "externalReferences": [
         {
           "type": "website",
@@ -1392,16 +1399,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
       "author": "Acrimon <joel.wejdenstal@gmail.com>",
       "name": "dashmap",
-      "version": "6.1.0",
+      "version": "6.2.1",
       "description": "Blazing fast concurrent HashMap for Rust.",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+          "content": "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
         }
       ],
       "licenses": [
@@ -1409,7 +1416,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/dashmap@6.1.0",
+      "purl": "pkg:cargo/dashmap@6.2.1",
       "externalReferences": [
         {
           "type": "documentation",
@@ -6262,16 +6269,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
       "author": "Tokio Contributors <team@tokio.rs>",
       "name": "tokio",
-      "version": "1.52.2",
+      "version": "1.52.3",
       "description": "An event-driven, non-blocking I/O platform for writing asynchronous I/O backed applications. ",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+          "content": "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
         }
       ],
       "licenses": [
@@ -6279,7 +6286,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/tokio@1.52.2",
+      "purl": "pkg:cargo/tokio@1.52.3",
       "externalReferences": [
         {
           "type": "website",
@@ -6324,16 +6331,16 @@
     },
     {
       "type": "library",
-      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.10",
+      "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
       "author": "Tower Maintainers <team@tower-rs.com>",
       "name": "tower-http",
-      "version": "0.6.10",
+      "version": "0.6.11",
       "description": "Tower middleware and utilities for HTTP clients and servers",
       "scope": "required",
       "hashes": [
         {
           "alg": "SHA-256",
-          "content": "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+          "content": "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
         }
       ],
       "licenses": [
@@ -6341,7 +6348,7 @@
           "expression": "MIT"
         }
       ],
-      "purl": "pkg:cargo/tower-http@0.6.10",
+      "purl": "pkg:cargo/tower-http@0.6.11",
       "externalReferences": [
         {
           "type": "website",
@@ -7570,12 +7577,12 @@
   ],
   "dependencies": [
     {
-      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2/pg_ripple_http#0.101.0",
+      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1/pg_ripple_http#0.128.1",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#axum@0.8.9",
         "registry+https://github.com/rust-lang/crates.io-index#constant_time_eq@0.4.2",
-        "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#deadpool-postgres@0.14.1",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",
         "registry+https://github.com/rust-lang/crates.io-index#hmac@0.13.0",
@@ -7585,10 +7592,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde_json@1.0.149",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sha2@0.11.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-postgres@0.7.17",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.10",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
         "registry+https://github.com/rust-lang/crates.io-index#tower_governor@0.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44",
         "registry+https://github.com/rust-lang/crates.io-index#tracing-subscriber@0.3.23",
@@ -7618,23 +7625,23 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#allocator-api2@0.2.21"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#half@2.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#hashbrown@0.17.0",
@@ -7644,7 +7651,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#half@2.7.1",
@@ -7653,14 +7660,14 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#atoi@2.0.0",
         "registry+https://github.com/rust-lang/crates.io-index#base64@0.22.1",
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
@@ -7671,68 +7678,68 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#half@2.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#num-integer@0.1.46",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#flatbuffers@25.12.19"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.2.0"
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#half@2.7.1"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0"
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0"
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#ahash@0.8.12",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.2.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0",
         "registry+https://github.com/rust-lang/crates.io-index#memchr@2.8.0",
         "registry+https://github.com/rust-lang/crates.io-index#num-traits@0.2.19",
         "registry+https://github.com/rust-lang/crates.io-index#regex@1.12.3",
@@ -7740,19 +7747,19 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow@58.2.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#arrow@58.3.0",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.2.0",
-        "registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.2.0"
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-arith@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-array@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-buffer@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-cast@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-data@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-ipc@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-ord@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-row@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-schema@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-select@58.3.0",
+        "registry+https://github.com/rust-lang/crates.io-index#arrow-string@58.3.0"
       ]
     },
     {
@@ -7814,7 +7821,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde_path_to_error@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
@@ -7924,7 +7931,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
         "registry+https://github.com/rust-lang/crates.io-index#crossbeam-utils@0.8.21",
@@ -7939,7 +7946,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#async-trait@0.1.89",
         "registry+https://github.com/rust-lang/crates.io-index#deadpool@0.12.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-postgres@0.7.17",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
@@ -7947,7 +7954,7 @@
     {
       "ref": "registry+https://github.com/rust-lang/crates.io-index#deadpool-runtime@0.1.4",
       "dependsOn": [
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
       ]
     },
     {
@@ -7956,7 +7963,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#deadpool-runtime@0.1.4",
         "registry+https://github.com/rust-lang/crates.io-index#lazy_static@1.5.0",
         "registry+https://github.com/rust-lang/crates.io-index#num_cpus@1.17.0",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
       ]
     },
     {
@@ -8072,7 +8079,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#governor@0.10.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#cfg-if@1.0.4",
-        "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.1.0",
+        "registry+https://github.com/rust-lang/crates.io-index#dashmap@6.2.1",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-timer@3.0.3",
         "registry+https://github.com/rust-lang/crates.io-index#futures-util@0.3.32",
@@ -8099,7 +8106,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#http@1.4.0",
         "registry+https://github.com/rust-lang/crates.io-index#indexmap@2.14.0",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
@@ -8184,7 +8191,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.38",
         "registry+https://github.com/rust-lang/crates.io-index#rustls-native-certs@0.8.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
@@ -8195,7 +8202,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#hyper@1.9.0",
         "registry+https://github.com/rust-lang/crates.io-index#hyper-util@0.1.20",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3"
       ]
     },
@@ -8214,7 +8221,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#percent-encoding@2.3.2",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
@@ -8234,7 +8241,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#itoa@1.0.18",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#smallvec@1.15.1",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#want@0.3.1"
       ]
     },
@@ -8618,7 +8625,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.38",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#thiserror@2.0.18",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tracing@0.1.44"
       ]
     },
@@ -8701,10 +8708,10 @@
         "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.228",
         "registry+https://github.com/rust-lang/crates.io-index#serde_urlencoded@0.7.1",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.10",
+        "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#url@2.5.8"
       ]
@@ -9006,7 +9013,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#postgres-types@0.2.13",
         "registry+https://github.com/rust-lang/crates.io-index#rand@0.10.1",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#whoami@2.1.1"
       ]
@@ -9015,7 +9022,7 @@
       "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio-rustls@0.26.4",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#rustls@0.23.38",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
       ]
     },
     {
@@ -9023,7 +9030,7 @@
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
       ]
     },
     {
@@ -9033,11 +9040,11 @@
         "registry+https://github.com/rust-lang/crates.io-index#futures-core@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#futures-sink@0.3.32",
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2"
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3"
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
         "registry+https://github.com/rust-lang/crates.io-index#libc@0.2.186",
@@ -9067,7 +9074,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#pin-project@1.1.11",
         "registry+https://github.com/rust-lang/crates.io-index#socket2@0.6.3",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-stream@0.1.18",
         "registry+https://github.com/rust-lang/crates.io-index#tower@0.5.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
@@ -9076,7 +9083,7 @@
       ]
     },
     {
-      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.10",
+      "ref": "registry+https://github.com/rust-lang/crates.io-index#tower-http@0.6.11",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#bitflags@2.11.0",
         "registry+https://github.com/rust-lang/crates.io-index#bytes@1.11.1",
@@ -9106,7 +9113,7 @@
         "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.17",
         "registry+https://github.com/rust-lang/crates.io-index#slab@0.4.12",
         "registry+https://github.com/rust-lang/crates.io-index#sync_wrapper@1.0.2",
-        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.2",
+        "registry+https://github.com/rust-lang/crates.io-index#tokio@1.52.3",
         "registry+https://github.com/rust-lang/crates.io-index#tokio-util@0.7.18",
         "registry+https://github.com/rust-lang/crates.io-index#tower-layer@0.3.3",
         "registry+https://github.com/rust-lang/crates.io-index#tower-service@0.3.3",

--- a/pg_ripple_http/src/lib.rs
+++ b/pg_ripple_http/src/lib.rs
@@ -1,0 +1,11 @@
+//! Library surface for `pg_ripple_http`, split out from the binary so that
+//! `tests/router_construction.rs` (v0.128.1 emergency containment) can build
+//! and exercise the router without a running PostgreSQL instance.
+
+pub mod arrow_encode;
+pub mod common;
+pub mod datalog;
+pub mod metrics;
+pub mod routing;
+pub mod spi_bridge;
+pub mod stream;

--- a/pg_ripple_http/src/main.rs
+++ b/pg_ripple_http/src/main.rs
@@ -15,15 +15,8 @@ use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
-pub mod arrow_encode;
-pub mod common;
-pub mod datalog;
-pub mod metrics;
-pub mod routing;
-pub mod spi_bridge;
-pub mod stream;
-
-use common::{AppState, env_or};
+use pg_ripple_http::common::{AppState, env_or};
+use pg_ripple_http::{metrics, routing};
 
 // ─── Compatibility constants (COMPAT-01, v0.71.0) ────────────────────────────
 

--- a/pg_ripple_http/src/routing/mod.rs
+++ b/pg_ripple_http/src/routing/mod.rs
@@ -148,7 +148,7 @@ pub(crate) use sparql_handlers::{
 /// Build the application [`Router`] and apply middleware layers.
 ///
 /// Called from `main` after the [`AppState`] and CORS policy are constructed.
-pub(crate) fn build_router(state: Arc<AppState>, max_body_bytes: usize, cors: CorsLayer) -> Router {
+pub fn build_router(state: Arc<AppState>, max_body_bytes: usize, cors: CorsLayer) -> Router {
     Router::new()
         // SPARQL 1.1 Protocol
         .route(
@@ -363,11 +363,11 @@ pub(crate) fn build_router(state: Arc<AppState>, max_body_bytes: usize, cors: Co
         .route("/temporal/facts", get(temporal_handlers::temporal_facts))
         // v0.125.0 FEAT-02: Temporal graph snapshot and diff endpoints.
         .route(
-            "/temporal/graphs/:iri/snapshot",
+            "/temporal/graphs/{iri}/snapshot",
             get(temporal_handlers::graph_snapshot),
         )
         .route(
-            "/temporal/graphs/:iri/diff",
+            "/temporal/graphs/{iri}/diff",
             get(temporal_handlers::graph_diff),
         )
         // v0.115.0 M16-02: PPRL REST API.
@@ -381,7 +381,7 @@ pub(crate) fn build_router(state: Arc<AppState>, max_body_bytes: usize, cors: Co
         .route("/dp/noisy_histogram", post(dp_handlers::dp_noisy_histogram))
         // v0.118.0 Feature 2: Privacy budget status endpoint.
         .route(
-            "/dp/budget/:dataset/:principal",
+            "/dp/budget/{dataset}/{principal}",
             get(dp_handlers::dp_budget_get),
         )
         // v0.115.0 M16-02: Entity-resolution REST API.

--- a/pg_ripple_http/tests/process_smoke.sh
+++ b/pg_ripple_http/tests/process_smoke.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# pg_ripple_http/tests/process_smoke.sh — v0.128.1 emergency containment.
+#
+# Starts the built pg_ripple_http binary against a real PostgreSQL instance
+# with pg_ripple installed, polls /health and /ready, then sends SIGTERM and
+# verifies a clean exit. This is the "does it actually start and serve
+# traffic" gate that a compile-only check cannot catch — Axum panics at
+# router-construction time happen only when the binary actually runs.
+#
+# Requires: a reachable PostgreSQL instance with `CREATE EXTENSION pg_ripple;`
+# already applied (point PG_RIPPLE_HTTP_PG_URL at it — e.g. a running release
+# image, or a `cargo pgrx start` instance in CI).
+#
+# Usage:
+#   PG_RIPPLE_HTTP_PG_URL="postgresql://postgres@localhost:5432/postgres" \
+#     bash pg_ripple_http/tests/process_smoke.sh [path-to-binary]
+#
+# Exit codes:
+#   0 — health/ready responded and the process shut down cleanly on SIGTERM
+#   1 — binary failed to start, ports never came up, or shutdown was unclean
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN="${1:-${REPO_ROOT}/target/debug/pg_ripple_http}"
+PORT="${PG_RIPPLE_HTTP_PORT:-18787}"
+PG_URL="${PG_RIPPLE_HTTP_PG_URL:-postgresql://postgres@localhost:5432/postgres}"
+
+if [ ! -x "${BIN}" ]; then
+  echo "ERROR: pg_ripple_http binary not found or not executable at ${BIN}" >&2
+  echo "Build it first: cargo build -p pg_ripple_http" >&2
+  exit 1
+fi
+
+echo "==> Starting pg_ripple_http (port ${PORT}) against ${PG_URL}"
+PG_RIPPLE_HTTP_PORT="${PORT}" PG_RIPPLE_HTTP_PG_URL="${PG_URL}" "${BIN}" &
+PID=$!
+
+cleanup() {
+  if kill -0 "${PID}" 2>/dev/null; then
+    kill -9 "${PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "==> Waiting for /health to respond..."
+UP=0
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    UP=1
+    break
+  fi
+  if ! kill -0 "${PID}" 2>/dev/null; then
+    echo "ERROR: pg_ripple_http exited before it started serving requests" >&2
+    wait "${PID}" || true
+    exit 1
+  fi
+  sleep 0.5
+done
+
+if [ "${UP}" -ne 1 ]; then
+  echo "ERROR: /health never responded within 15s" >&2
+  exit 1
+fi
+echo "OK: /health responded"
+
+echo "==> Checking /ready..."
+READY_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${PORT}/ready")
+if [ "${READY_STATUS}" != "200" ] && [ "${READY_STATUS}" != "503" ]; then
+  echo "ERROR: /ready returned unexpected status ${READY_STATUS}" >&2
+  exit 1
+fi
+echo "OK: /ready responded (${READY_STATUS})"
+
+echo "==> Sending SIGTERM and waiting for clean exit..."
+kill -TERM "${PID}"
+trap - EXIT
+
+if wait "${PID}"; then
+  echo "OK: process exited cleanly after SIGTERM"
+else
+  STATUS=$?
+  echo "ERROR: process exited with status ${STATUS} after SIGTERM" >&2
+  exit 1
+fi
+
+echo "==> pg_ripple_http process smoke test PASSED."

--- a/pg_ripple_http/tests/router_construction.rs
+++ b/pg_ripple_http/tests/router_construction.rs
@@ -1,0 +1,171 @@
+//! v0.128.1 emergency containment (HTTP startup): the axum router must build
+//! without panicking and every registered route must resolve to a real
+//! response (auth/method/handler) instead of a 404 — with no live
+//! PostgreSQL connection required. Regression test for the Axum 0.7-style
+//! `:capture` routes that panic Axum 0.8's router builder.
+
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use dashmap::DashMap;
+use deadpool_postgres::{Config, Runtime};
+use tokio_postgres::NoTls;
+use tower::ServiceExt;
+use tower_http::cors::CorsLayer;
+
+use pg_ripple_http::common::AppState;
+use pg_ripple_http::metrics::Metrics;
+use pg_ripple_http::routing::build_router;
+
+/// Every path registered in `routing::build_router`, with `{param}`
+/// segments replaced by a literal `x`. Kept in sync with that route table.
+const ROUTES: &[&str] = &[
+    "/sparql",
+    "/sparql/stream",
+    "/rag",
+    "/health",
+    "/ready",
+    "/health/ready",
+    "/metrics",
+    "/metrics/extension",
+    "/void",
+    "/service",
+    "/openapi.yaml",
+    "/datalog/rules",
+    "/datalog/rules/x",
+    "/datalog/rules/x/builtin",
+    "/datalog/rules/x/add",
+    "/datalog/rules/x/x",
+    "/datalog/rules/x/enable",
+    "/datalog/rules/x/disable",
+    "/datalog/infer/x",
+    "/datalog/infer/x/stats",
+    "/datalog/infer/x/agg",
+    "/datalog/infer/x/wfs",
+    "/datalog/infer/x/demand",
+    "/datalog/infer/x/lattice",
+    "/datalog/query/x",
+    "/datalog/constraints",
+    "/datalog/constraints/x",
+    "/datalog/stats/cache",
+    "/datalog/stats/tabling",
+    "/datalog/lattices",
+    "/datalog/views",
+    "/datalog/views/x",
+    "/explorer",
+    "/admin/bench-history",
+    "/admin/diagnostic-snapshot",
+    "/flight/do_get",
+    "/subscribe/x",
+    "/confidence/load",
+    "/confidence/shacl-score",
+    "/confidence/shacl-report",
+    "/confidence/vacuum",
+    "/confidence/update",
+    "/confidence/bulk-update",
+    "/pagerank/run",
+    "/pagerank/results",
+    "/pagerank/status",
+    "/pagerank/vacuum-dirty",
+    "/pagerank/export",
+    "/pagerank/explain/x",
+    "/pagerank/queue-stats",
+    "/centrality/run",
+    "/centrality/results",
+    "/pagerank/find-duplicates",
+    "/explain",
+    "/hypothetical",
+    "/rule-conflicts/x",
+    "/rule-libraries",
+    "/rule-libraries/x/stream",
+    "/rule-libraries/x/subscribe",
+    "/rules/draft",
+    "/rules/validate",
+    "/rules/x/explain",
+    "/temporal/mark",
+    "/temporal/point_in_time",
+    "/temporal/facts",
+    "/temporal/graphs/x/snapshot",
+    "/temporal/graphs/x/diff",
+    "/pprl/bloom_encode",
+    "/pprl/dice_similarity",
+    "/dp/noisy_count",
+    "/dp/noisy_histogram",
+    "/dp/budget/x/x",
+    "/entity-resolution/resolve",
+    "/entity-resolution/evaluate",
+    "/entity-resolution/monitoring/enable",
+    "/entity-resolution/monitoring/disable",
+    "/proof-tree/x/x/x",
+    "/tenants",
+    "/tenants/x",
+    "/tenants/x/quota",
+    "/federation/x/auth-status",
+    "/json-mapping/x/writeback",
+    "/json-mapping/x/writeback/status",
+];
+
+/// Builds an `AppState` backed by a lazy pool pointed at a closed local port.
+/// `deadpool_postgres` never connects at construction time, and connects to
+/// a closed port on `127.0.0.1` fail instantly (ECONNREFUSED) rather than
+/// timing out, so every handler that touches `state.pool` still returns
+/// quickly without a real PostgreSQL instance.
+fn test_state() -> Arc<AppState> {
+    let mut cfg = Config::new();
+    cfg.url = Some("postgresql://127.0.0.1:1/pg_ripple_router_test".to_owned());
+    let pool = cfg
+        .create_pool(Some(Runtime::Tokio1), NoTls)
+        .expect("pool config is valid; no connection is attempted at creation");
+
+    Arc::new(AppState {
+        pool,
+        auth_token: Some("test-auth-token".to_owned()),
+        datalog_write_token: None,
+        trust_proxy: None,
+        metrics: Metrics::new(),
+        ever_connected: AtomicBool::new(false),
+        arrow_flight_secret: None,
+        arrow_unsigned_tickets_allowed: false,
+        arrow_nonce_cache: DashMap::new(),
+        arrow_nonce_cache_max: 10_000,
+        cors_is_permissive: false,
+        metrics_token: None,
+        auth_realm: "pg_ripple".to_owned(),
+        replica_pool: None,
+    })
+}
+
+#[tokio::test]
+async fn router_builds_without_panicking_and_every_route_resolves() {
+    let state = test_state();
+
+    // Router construction must not panic — this is exactly what Axum 0.8
+    // does when a route still uses the removed `:capture` syntax.
+    let router = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        build_router(state, 1_048_576, CorsLayer::new())
+    }))
+    .expect("router construction panicked — check for obsolete `:capture` route syntax");
+
+    for path in ROUTES {
+        let request = Request::builder()
+            .method("GET")
+            .uri(*path)
+            .body(Body::empty())
+            .expect("request build is infallible for these static paths");
+
+        let response = router
+            .clone()
+            .oneshot(request)
+            .await
+            .unwrap_or_else(|e| panic!("route {path} dispatch failed: {e}"));
+
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "route {path} returned 404 — stale or mistyped path pattern"
+        );
+    }
+}

--- a/sbom.json
+++ b/sbom.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
-  "specVersion": "1.4",
+  "specVersion": "1.3",
   "version": 1,
-  "serialNumber": "urn:uuid:4d3753cf-13d9-4ec0-8566-71de87874577",
+  "serialNumber": "urn:uuid:3a9b4542-c7b3-4729-bfb5-6d6dea6be709",
   "metadata": {
-    "timestamp": "2026-05-21T20:19:28.965608000Z",
+    "timestamp": "2026-08-26T18:33:34.797807000Z",
     "tools": [
       {
         "vendor": "CycloneDX",
@@ -14,9 +14,9 @@
     ],
     "component": {
       "type": "library",
-      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.127.0",
+      "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1#pg_ripple@0.128.1",
       "name": "pg_ripple",
-      "version": "0.128.0",
+      "version": "0.128.1",
       "description": "High-performance RDF triple store with native SPARQL query execution for PostgreSQL 18",
       "scope": "required",
       "licenses": [
@@ -24,7 +24,7 @@
           "expression": "Apache-2.0"
         }
       ],
-      "purl": "pkg:cargo/pg_ripple@0.127.0?download_url=file://.",
+      "purl": "pkg:cargo/pg_ripple@0.128.1?download_url=file://.",
       "externalReferences": [
         {
           "type": "vcs",
@@ -34,10 +34,10 @@
       "components": [
         {
           "type": "library",
-          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.127.0 bin-target-0",
+          "bom-ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1#pg_ripple@0.128.1 bin-target-0",
           "name": "pg_ripple",
-          "version": "0.127.0",
-          "purl": "pkg:cargo/pg_ripple@0.127.0?download_url=file://.#src/lib.rs"
+          "version": "0.128.1",
+          "purl": "pkg:cargo/pg_ripple@0.128.1?download_url=file://.#src/lib.rs"
         }
       ]
     },
@@ -325,7 +325,7 @@
     {
       "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#bindgen@0.72.1",
-      "author": "Jyun-Yan You <jyyou.tw@gmail.com>, Emilio Cobos \u00c1lvarez <emilio@crisal.io>, Nick Fitzgerald <fitzgen@gmail.com>, The Servo project developers",
+      "author": "Jyun-Yan You <jyyou.tw@gmail.com>, Emilio Cobos Álvarez <emilio@crisal.io>, Nick Fitzgerald <fitzgen@gmail.com>, The Servo project developers",
       "name": "bindgen",
       "version": "0.72.1",
       "description": "Automatically generates Rust FFI bindings to C and C++ libraries.",
@@ -1634,7 +1634,7 @@
     {
       "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#generic-array@0.14.7",
-      "author": "Bart\u0142omiej Kami\u0144ski <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>",
+      "author": "Bartłomiej Kamiński <fizyk20@gmail.com>, Aaron Trent <novacrazy@gmail.com>",
       "name": "generic-array",
       "version": "0.14.7",
       "description": "Generic types implementing functionality of arrays",
@@ -1994,7 +1994,7 @@
     {
       "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#iana-time-zone@0.1.65",
-      "author": "Andrew Straw <strawman@astraw.com>, Ren\u00e9 Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>",
+      "author": "Andrew Straw <strawman@astraw.com>, René Kijewski <rene.kijewski@fu-berlin.de>, Ryan Lopopolo <rjl@hyperbo.la>",
       "name": "iana-time-zone",
       "version": "0.1.65",
       "description": "get the IANA time zone for the current system",
@@ -2396,7 +2396,7 @@
     {
       "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#is_ci@1.2.0",
-      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "author": "Kat Marchán <kzm@zkat.tech>",
       "name": "is_ci",
       "version": "1.2.0",
       "description": "Super lightweight CI environment checker. Just tells you if you're in CI or not without much fuss.",
@@ -4816,7 +4816,7 @@
     {
       "type": "library",
       "bom-ref": "registry+https://github.com/rust-lang/crates.io-index#supports-color@3.0.2",
-      "author": "Kat March\u00e1n <kzm@zkat.tech>",
+      "author": "Kat Marchán <kzm@zkat.tech>",
       "name": "supports-color",
       "version": "3.0.2",
       "description": "Detects whether a terminal supports color, and gives details about that support.",
@@ -5833,7 +5833,7 @@
       "author": "myrrlyn <self@myrrlyn.dev>",
       "name": "wyz",
       "version": "0.5.1",
-      "description": "myrrlyn\u2019s utility collection",
+      "description": "myrrlyn’s utility collection",
       "scope": "required",
       "hashes": [
         {
@@ -6201,7 +6201,7 @@
   ],
   "dependencies": [
     {
-      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple2#pg_ripple@0.127.0",
+      "ref": "path+file:///Users/geir.gronmo/projects/pg-ripple1#pg_ripple@0.128.1",
       "dependsOn": [
         "registry+https://github.com/rust-lang/crates.io-index#chrono@0.4.44",
         "registry+https://github.com/rust-lang/crates.io-index#hex@0.4.3",

--- a/sql/pg_ripple--0.128.0--0.128.1.sql
+++ b/sql/pg_ripple--0.128.0--0.128.1.sql
@@ -1,0 +1,11 @@
+-- Migration 0.128.0 → 0.128.1: Emergency containment and safe patch
+--
+-- Changes in this release:
+--   - enable_json_writeback() now fails with an error instead of setting
+--     writeback_enabled = true when enqueue-trigger coverage is incomplete
+--     (C18-01 containment). No schema change — behavior change in Rust only.
+--   - pg_ripple.feature_status() reports json_mapping_writeback as 'broken'
+--     instead of 'implemented' pending the v0.129.0 trigger-architecture repair.
+--   - pg_ripple_http and Docker image fixes only; no extension schema changes.
+--
+-- No SQL statements required for this migration.

--- a/src/feature_status.rs
+++ b/src/feature_status.rs
@@ -11,6 +11,7 @@
 //! - `manual_refresh`— feature is correct only when a manual refresh is invoked
 //! - `stub`          — API exists but production behavior is not implemented
 //! - `degraded`      — dependency or configuration is missing; fallback is active
+//! - `broken`        — known correctness defect; do not rely on this in production
 //! - `planned`       — roadmap item exists, no user-facing implementation
 
 #[pgrx::pg_schema]
@@ -463,16 +464,24 @@ mod pg_ripple {
                 Some("docs/src/features/loading-data.md".to_string()),
                 Some("src/json_mapping.rs".to_string()),
             ),
-            // ── JSON mapping relational writeback (v0.128.0 JSON-WRITEBACK-01) ─
+            // ── JSON mapping relational writeback (v0.128.0 JSON-WRITEBACK-01;
+            // async path marked broken by v0.128.1 C18-01 emergency containment) ─
             (
                 "json_mapping_writeback".to_string(),
-                "implemented".to_string(),
+                "broken".to_string(),
                 None,
                 Some(
                     "JSON-WRITEBACK-01 (v0.128.0): writeback_json_row() / \
                      writeback_json_row_delete() propagate RDF graph changes back to \
-                     the source relational table. enable_json_writeback() installs VP \
-                     delta triggers for automatic async queueing. \
+                     the source relational table and remain safe to call directly. \
+                     v0.128.1 C18-01: enable_json_writeback() previously installed VP \
+                     delta triggers per predicate but set writeback_enabled = true even \
+                     when some or all triggers failed to install (e.g. a predicate not \
+                     yet ingested), silently under-covering the async event path. It now \
+                     fails closed with an error and leaves writeback_enabled = false \
+                     unless every mapped predicate got a working trigger. Full repair of \
+                     the underlying trigger-based design lands in v0.129.0 \
+                     (plans/pg-ripple-production-readiness-plan.md#v01290--json-writeback-and-mutation-integrity). \
                      Conflict policies: replace (upsert), skip, error. \
                      GUC: pg_ripple.json_writeback_batch_size (default 100)."
                         .to_string(),

--- a/src/json_mapping.rs
+++ b/src/json_mapping.rs
@@ -990,6 +990,13 @@ pub fn enable_json_writeback_impl(mapping: &str) {
     // For each predicate IRI, find the VP delta table and install trigger.
     let safe_mapping = mapping.replace(|c: char| !c.is_alphanumeric(), "_");
 
+    // v0.128.1 C18-01 containment: track exactly which predicates got a
+    // working enqueue trigger installed. Until v0.129.0 rebuilds this on a
+    // storage-level event path, `writeback_enabled` must never claim more
+    // coverage than what was actually installed just now.
+    let mut installed = 0usize;
+    let mut uncovered: Vec<String> = Vec::new();
+
     for pred_iri in &pred_iris {
         // Look up predicate_id in dictionary.
         let pred_id_opt: Option<i64> = pgrx::Spi::get_one_with_args::<i64>(
@@ -1000,7 +1007,10 @@ pub fn enable_json_writeback_impl(mapping: &str) {
 
         let pred_id = match pred_id_opt {
             Some(id) => id,
-            None => continue, // predicate not yet stored
+            None => {
+                uncovered.push(format!("{pred_iri} (no dictionary entry yet)"));
+                continue;
+            }
         };
 
         // Check whether the delta table exists.
@@ -1015,6 +1025,7 @@ pub fn enable_json_writeback_impl(mapping: &str) {
         .unwrap_or(false);
 
         if !delta_exists {
+            uncovered.push(format!("{pred_iri} (no {delta_table} table yet)"));
             continue;
         }
 
@@ -1029,15 +1040,29 @@ pub fn enable_json_writeback_impl(mapping: &str) {
              FOR EACH ROW EXECUTE FUNCTION _pg_ripple.json_writeback_enqueue_fn('{q_mapping}')"
         );
 
-        pgrx::Spi::run_with_args(&create_trigger_sql, &[]).unwrap_or_else(|e| {
-            pgrx::warning!(
-                "enable_json_writeback: could not install trigger on {}: {e}",
-                delta_table
-            )
-        });
+        match pgrx::Spi::run_with_args(&create_trigger_sql, &[]) {
+            Ok(_) => installed += 1,
+            Err(e) => uncovered.push(format!("{pred_iri} (trigger install failed: {e})")),
+        }
     }
 
-    // Set writeback_enabled = true.
+    // v0.128.1 C18-01 containment: fail closed rather than silently reporting
+    // "enabled" when the enqueue path is incomplete or entirely missing.
+    if installed == 0 || !uncovered.is_empty() {
+        pgrx::error!(
+            "enable_json_writeback: cannot enable — incomplete enqueue coverage \
+             ({installed} of {} predicate(s) covered); async writeback is unavailable \
+             for this mapping until every mapped predicate has been ingested at least \
+             once. Uncovered: [{}]. writeback_enabled was left false; use \
+             writeback_json_row()/writeback_json_row_delete() for direct writeback \
+             in the meantime.",
+            pred_iris.len(),
+            uncovered.join(", ")
+        );
+    }
+
+    // Set writeback_enabled = true — only reached once every mapped predicate
+    // has a validated enqueue trigger installed.
     pgrx::Spi::run_with_args(
         "UPDATE _pg_ripple.json_mappings SET writeback_enabled = true WHERE name = $1",
         &[pgrx::datum::DatumWithOid::from(mapping)],

--- a/tests/container/test_pg_hba.sh
+++ b/tests/container/test_pg_hba.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# tests/container/test_pg_hba.sh — v0.128.1 emergency containment
+# (production database authentication).
+#
+# Verifies that the pg_ripple production Docker image does NOT accept
+# passwordless remote PostgreSQL connections by default, and that normal
+# SCRAM authentication and local Unix-socket access still work as documented.
+#
+# Background: docker/00-pg_hba.sh used to add unconditional `trust` rules for
+# all external TCP connections to every built image, including production
+# pulls — any reachable client got an unauthenticated superuser connection.
+# It is now inert unless PG_RIPPLE_DEV_TRUST_AUTH=1 is set (see that script).
+#
+# Usage:
+#   bash tests/container/test_pg_hba.sh              # builds the image locally
+#   IMAGE_REF=<already-built-ref> bash tests/container/test_pg_hba.sh
+#     # e.g. the digest a release workflow just pushed — skips the local build
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed (or the image is not secure by default)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE_TAG="${IMAGE_REF:-pg_ripple:hba-test}"
+CONTAINER_NAME="pg_ripple_hba_test_$$"
+HOST_PORT="15432"
+PG_PASSWORD="hba-test-password"
+FAILURES=0
+
+cleanup() {
+  docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if [ -n "${IMAGE_REF:-}" ]; then
+  echo "==> Using already-built image ${IMAGE_TAG} (skipping local build)"
+else
+  echo "==> Building production image (docker/00-pg_hba.sh must stay inert by default)..."
+  docker build --tag "${IMAGE_TAG}" "${REPO_ROOT}"
+fi
+
+echo "==> Starting container with SCRAM password, no PG_RIPPLE_DEV_TRUST_AUTH..."
+docker run --rm -d \
+  --name "${CONTAINER_NAME}" \
+  -p "${HOST_PORT}:5432" \
+  -e POSTGRES_PASSWORD="${PG_PASSWORD}" \
+  "${IMAGE_TAG}" >/dev/null
+
+echo -n "==> Waiting for PostgreSQL to accept connections..."
+READY=0
+for _ in $(seq 1 60); do
+  if docker exec "${CONTAINER_NAME}" pg_isready -U postgres >/dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+echo ""
+if [ "${READY}" -ne 1 ]; then
+  echo "ERROR: PostgreSQL never became ready" >&2
+  docker logs "${CONTAINER_NAME}" >&2 || true
+  exit 1
+fi
+
+check() {
+  local description="$1"
+  shift
+  echo -n "  ${description} ... "
+  if "$@"; then
+    echo "OK"
+  else
+    echo "FAILED"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# 1. Passwordless remote TCP auth must fail (this is the regression this
+#    patch fixes — it used to succeed unconditionally).
+passwordless_tcp_fails() {
+  ! PGPASSWORD="" psql "host=127.0.0.1 port=${HOST_PORT} user=postgres dbname=postgres sslmode=disable connect_timeout=5" \
+    -c "SELECT 1" >/dev/null 2>&1
+}
+check "passwordless remote TCP auth fails" passwordless_tcp_fails
+
+# 2. SCRAM auth with the configured password must still succeed.
+scram_auth_succeeds() {
+  PGPASSWORD="${PG_PASSWORD}" psql "host=127.0.0.1 port=${HOST_PORT} user=postgres dbname=postgres sslmode=disable connect_timeout=5" \
+    -c "SELECT 1" >/dev/null 2>&1
+}
+check "SCRAM auth with configured password succeeds" scram_auth_succeeds
+
+# 3. Local Unix-socket access from inside the container (the documented
+#    policy: the entrypoint and administrators connect locally without a
+#    password prompt, matching the upstream postgres:18 image default).
+local_socket_succeeds() {
+  docker exec -u postgres "${CONTAINER_NAME}" psql -U postgres -c "SELECT 1" >/dev/null 2>&1
+}
+check "local Unix-socket access succeeds" local_socket_succeeds
+
+echo ""
+if [ "${FAILURES}" -eq 0 ]; then
+  echo "==> All pg_hba container auth tests PASSED."
+  exit 0
+else
+  echo "==> ${FAILURES} pg_hba container auth test(s) FAILED."
+  exit 1
+fi

--- a/tests/pg_regress/expected/diagnostic_report.out
+++ b/tests/pg_regress/expected/diagnostic_report.out
@@ -56,7 +56,7 @@ SELECT
     (SELECT value FROM pg_ripple.diagnostic_report() WHERE key = 'compiled_version') AS cv;
    sv   |   cv    
 --------+---------
- 0.98.0 | 0.128.0
+ 0.98.0 | 0.128.1
 (1 row)
 
 -- GUC values should be valid

--- a/tests/pg_regress/expected/feature_status.out
+++ b/tests/pg_regress/expected/feature_status.out
@@ -23,6 +23,7 @@ WHERE status NOT IN (
     'manual_refresh',
     'stub',
     'degraded',
+    'broken',
     'planned'
 );
  invalid_statuses 

--- a/tests/pg_regress/expected/v0128_json_writeback.out
+++ b/tests/pg_regress/expected/v0128_json_writeback.out
@@ -453,6 +453,52 @@ WHERE feature_name = 'json_mapping_writeback';
                           1
 (1 row)
 
+-- ─── JWB-22: enable_json_writeback() fails closed on incomplete enqueue
+-- coverage (v0.128.1 C18-01 emergency containment) ───────────────────────────
+CREATE TABLE IF NOT EXISTS public.uncovered_test (
+    item_id   TEXT PRIMARY KEY,
+    item_name TEXT
+);
+-- Mapped predicates below have never been ingested, so no dictionary entry
+-- or VP delta table exists for them — enqueue coverage cannot be complete.
+SELECT pg_ripple.register_json_mapping(
+    'uncovered_writeback',
+    '{"item_id":   "http://example.org/v0128-1/uncovered-id",
+      "item_name": "http://example.org/v0128-1/uncovered-name"}'::jsonb,
+    NULL, NULL, NULL, NULL, NULL, NULL
+);
+ register_json_mapping 
+-----------------------
+ 
+(1 row)
+
+UPDATE _pg_ripple.json_mappings
+SET writeback_table        = 'uncovered_test',
+    writeback_schema       = 'public',
+    writeback_key_columns  = ARRAY['item_id'],
+    writeback_conflict_policy = 'replace'
+WHERE name = 'uncovered_writeback';
+DO $$
+BEGIN
+    BEGIN
+        PERFORM pg_ripple.enable_json_writeback('uncovered_writeback');
+        RAISE NOTICE 'JWB-22 FAIL: enable_json_writeback() should have raised for incomplete coverage';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'JWB-22 PASS: enable_json_writeback() failed closed: %', SQLERRM;
+    END;
+END;
+$$;
+-- writeback_enabled must remain false — no false-positive "enabled" claim.
+SELECT writeback_enabled AS jwb22_writeback_enabled_stays_false
+FROM _pg_ripple.json_mappings
+WHERE name = 'uncovered_writeback';
+ jwb22_writeback_enabled_stays_false 
+-------------------------------------
+ f
+(1 row)
+
+DELETE FROM _pg_ripple.json_mappings WHERE name = 'uncovered_writeback';
+DROP TABLE IF EXISTS public.uncovered_test;
 -- ─── Cleanup ─────────────────────────────────────────────────────────────────
 DELETE FROM _pg_ripple.json_mappings WHERE name = 'contacts_writeback';
 DROP TABLE IF EXISTS public.contacts_test;

--- a/tests/pg_regress/sql/feature_status.sql
+++ b/tests/pg_regress/sql/feature_status.sql
@@ -20,6 +20,7 @@ WHERE status NOT IN (
     'manual_refresh',
     'stub',
     'degraded',
+    'broken',
     'planned'
 );
 

--- a/tests/pg_regress/sql/v0128_json_writeback.sql
+++ b/tests/pg_regress/sql/v0128_json_writeback.sql
@@ -365,6 +365,49 @@ SELECT COUNT(*) AS jwb21_feature_status_entry
 FROM pg_ripple.feature_status()
 WHERE feature_name = 'json_mapping_writeback';
 
+-- ─── JWB-22: enable_json_writeback() fails closed on incomplete enqueue
+-- coverage (v0.128.1 C18-01 emergency containment) ───────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.uncovered_test (
+    item_id   TEXT PRIMARY KEY,
+    item_name TEXT
+);
+
+-- Mapped predicates below have never been ingested, so no dictionary entry
+-- or VP delta table exists for them — enqueue coverage cannot be complete.
+SELECT pg_ripple.register_json_mapping(
+    'uncovered_writeback',
+    '{"item_id":   "http://example.org/v0128-1/uncovered-id",
+      "item_name": "http://example.org/v0128-1/uncovered-name"}'::jsonb,
+    NULL, NULL, NULL, NULL, NULL, NULL
+);
+
+UPDATE _pg_ripple.json_mappings
+SET writeback_table        = 'uncovered_test',
+    writeback_schema       = 'public',
+    writeback_key_columns  = ARRAY['item_id'],
+    writeback_conflict_policy = 'replace'
+WHERE name = 'uncovered_writeback';
+
+DO $$
+BEGIN
+    BEGIN
+        PERFORM pg_ripple.enable_json_writeback('uncovered_writeback');
+        RAISE NOTICE 'JWB-22 FAIL: enable_json_writeback() should have raised for incomplete coverage';
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'JWB-22 PASS: enable_json_writeback() failed closed: %', SQLERRM;
+    END;
+END;
+$$;
+
+-- writeback_enabled must remain false — no false-positive "enabled" claim.
+SELECT writeback_enabled AS jwb22_writeback_enabled_stays_false
+FROM _pg_ripple.json_mappings
+WHERE name = 'uncovered_writeback';
+
+DELETE FROM _pg_ripple.json_mappings WHERE name = 'uncovered_writeback';
+DROP TABLE IF EXISTS public.uncovered_test;
+
 -- ─── Cleanup ─────────────────────────────────────────────────────────────────
 
 DELETE FROM _pg_ripple.json_mappings WHERE name = 'contacts_writeback';


### PR DESCRIPTION
## Summary

Out-of-band safety patch for v0.128.0, per the plan in
[plans/pg-ripple-production-readiness-plan.md](https://github.com/trickle-labs/pg-ripple/blob/main/plans/pg-ripple-production-readiness-plan.md#v01281--emergency-containment-and-safe-patch).
Nothing new is added — this only removes unsafe behavior.

- **HTTP startup crash**: `pg_ripple_http` still used the Axum 0.7 `:capture` route syntax on 3 routes (`/temporal/graphs/:iri/{snapshot,diff}`, `/dp/budget/:dataset/:principal`). Axum 0.8 panics at router-construction time on that syntax, so the process could exit before ever binding a port. Fixed the routes to `{capture}` syntax. Added `pg_ripple_http/tests/router_construction.rs` (builds the full router + dispatches to every route, no live DB needed) and `pg_ripple_http/tests/process_smoke.sh` (real binary, real DB, `/health`+`/ready` polling, clean `SIGTERM` exit). Gave `pg_ripple_http` a library target (`src/lib.rs`) so the router can be built in-process by tests.
- **Passwordless production database auth**: `docker/00-pg_hba.sh` added unconditional `trust` rules for all external TCP connections to every built image, including production pulls. It's now inert unless `PG_RIPPLE_DEV_TRUST_AUTH=1` is explicitly set (dev only). `docker-compose.yml` now binds PostgreSQL to `127.0.0.1` by default. Added `tests/container/test_pg_hba.sh` (passwordless TCP fails, SCRAM succeeds, local socket unaffected), wired into the release workflow against the just-pushed image digest.
- **False-positive async writeback**: `enable_json_writeback()` always set `writeback_enabled = true` even when some predicates never got a working enqueue trigger installed (missing dictionary entry, missing VP delta table, or a failed trigger create), silently under-covering the async event path. It now fails closed with a descriptive error and leaves `writeback_enabled = false` unless every mapped predicate is covered. Direct `writeback_json_row()`/`writeback_json_row_delete()` are unaffected. `feature_status()` now reports `json_mapping_writeback` as `broken` pending the full v0.129.0 trigger-architecture repair. Added regression coverage (JWB-22 in `tests/pg_regress/sql/v0128_json_writeback.sql`).

Also: version bump to 0.128.1 (Cargo.toml ×2, `pg_ripple.control`, `docker-compose.yml`, both SBOMs), comment-only migration script (no schema changes), CHANGELOG/ROADMAP updates, and new CI gates (`http-router-construction`, `http-process-smoke`, `container-auth-negative-test`; the writeback fail-closed test rides the existing pg_regress gate).

### Not included (flagging, not fixing here)
- The `## [0.128.0]` GitHub release page itself doesn't yet have a known-issues notice added — that's an edit to an already-published external release page, so I left it for a maintainer to do explicitly (`gh release edit v0.128.0 ...`) rather than doing it as a side effect of this PR.
- `just bump-version` is currently broken (a `$$`-escaping bug causes it to silently no-op most of its `sed` replacements and drop a garbage file) — worked around by applying the version bump by hand; the recipe itself is unrelated to this patch so I didn't fix it.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --features pg18 -- -D warnings` (pre-existing failures in `src/telemetry.rs` / `src/sparql/execute/update.rs`, unrelated to this diff, confirmed present on `main` before this branch)
- [x] `cargo build -p pg_ripple_http`
- [x] `cargo test -p pg_ripple_http --test router_construction` — confirmed it catches the exact Axum panic when the old `:capture` syntax is reintroduced
- [x] `cargo pgrx regress pg18 v0128_json_writeback` — passes, including new JWB-22 fail-closed coverage
- [x] `scripts/check_migration_headers.sh`, `check_dep_versions.sh`, `check_api_drift.py`, `check_roadmap_evidence.py`, `check_roadmap_status.py`, `check_no_security_definer.sh`, `check_security_definer_search_path.sh`, `check_no_unreachable_in_production.sh`, `check_github_actions_pinned.sh` — all pass
- [ ] `pg_ripple_http/tests/process_smoke.sh` and `tests/container/test_pg_hba.sh` are exercised by the new CI jobs (not run end-to-end locally — building the full production Docker image / pgrx extension from scratch here would take too long for this session)